### PR TITLE
Added image circleci-php7.4-node16-composer1

### DIFF
--- a/cicd/circleci-php7.4-node16-composer1/Dockerfile
+++ b/cicd/circleci-php7.4-node16-composer1/Dockerfile
@@ -1,0 +1,59 @@
+FROM circleci/php:7.4.27-cli-node
+
+# Make composer packages executable.
+ENV PATH="/home/circleci/.composer/vendor/bin:${PATH}"
+
+# Downgrade composer to 1.x
+USER root
+RUN composer self-update --1
+USER circleci
+
+# Install drush and prestissimo.
+RUN composer global require drush/drush-launcher:^0.8.0 hirak/prestissimo \
+  && composer clearcache
+
+# Upgrade packages
+RUN sudo apt update && sudo apt upgrade && sudo apt clean
+
+# Install vim based on popular demand.
+RUN sudo apt-get update && sudo apt-get install vim && sudo apt-get clean
+
+# Add gcloud CLI and kubectl
+ENV GCLOUD_VERSION 348.0.0-0
+RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | sudo tee -a /etc/apt/sources.list.d/google-cloud-sdk.list \
+  && sudo apt-get install apt-transport-https ca-certificates \
+  && curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key --keyring /usr/share/keyrings/cloud.google.gpg add - \
+  && sudo apt-get update && sudo apt-get install google-cloud-sdk=${GCLOUD_VERSION} kubectl \
+  && sudo apt-get clean
+
+# Install AWS cli and aws-iam-authenticator
+RUN sudo apt install -y awscli git python3 \
+  && curl -o /tmp/aws-iam-authenticator https://amazon-eks.s3.us-west-2.amazonaws.com/1.18.9/2020-11-02/bin/linux/amd64/aws-iam-authenticator \
+  && chmod +x /tmp/aws-iam-authenticator \
+  && sudo mv /tmp/aws-iam-authenticator /bin/aws-iam-authenticator
+
+# Install Azure cli
+RUN curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash
+
+# Install Helm 3
+ENV HELM_VERSION v3.6.3
+ENV FILENAME helm-${HELM_VERSION}-linux-amd64.tar.gz
+ENV HELM_URL https://get.helm.sh/${FILENAME}
+
+RUN curl -o /tmp/$FILENAME ${HELM_URL} \
+  && tar -zxvf /tmp/${FILENAME} -C /tmp \
+  && rm /tmp/${FILENAME} \
+  && sudo mv /tmp/linux-amd64/helm /bin/helm \
+  && helm repo add bitnami https://charts.bitnami.com/bitnami \
+  && helm repo add minio https://helm.min.io/ \
+  && helm repo add wunderio https://storage.googleapis.com/charts.wdr.io \
+  && helm repo add percona https://percona.github.io/percona-helm-charts/ \
+  && helm plugin install https://github.com/quintush/helm-unittest --version 0.2.4
+
+# NOTE: quintush/helm-unittest v0.2.0 release breaks helm tests.
+
+# TODO: when https://github.com/lrills/helm-unittest/issues/87 is merged,
+# switch back to using https://github.com/lrills/helm-unittest as the source
+
+# Add custom php config and lift memory limit.
+COPY conf/php/memory.ini /usr/local/etc/php/conf.d/memory.ini

--- a/cicd/circleci-php7.4-node16-composer1/README.md
+++ b/cicd/circleci-php7.4-node16-composer1/README.md
@@ -1,0 +1,14 @@
+# silta-circleci
+A docker image used circleCI, based on `circleci/php:7.4-cli-node` with the following additions:
+
+- Composer configured correctly
+- Drush-launcher, prestissimo and coder pre-installed
+- Vim, useful for debugging
+- The google cloud cli, kubernetes and helm
+
+## Versions
+- PHP: 7.4.27
+- Composer: 1.x
+- Node: 16.13.1
+- GCloud: 348.0.0-0
+- Helm: v3.6.3

--- a/cicd/circleci-php7.4-node16-composer1/TAGS
+++ b/cicd/circleci-php7.4-node16-composer1/TAGS
@@ -1,0 +1,4 @@
+circleci-php7.4-node16-composer1
+circleci-php7.4.27-node16.13.1-composer1
+circleci-php7.4-node16-composer1-v0.1
+circleci-php7.4-node16-composer1-v0.1.6

--- a/cicd/circleci-php7.4-node16-composer1/conf/php/memory.ini
+++ b/cicd/circleci-php7.4-node16-composer1/conf/php/memory.ini
@@ -1,0 +1,1 @@
+memory_limit = -1


### PR DESCRIPTION
Changes proposed in this PR:
- add image for circleci with php 7.4, node 16 and composer 1

The image is an exact copy of the circleci-php7.4-node14-composer1 image, with the exception that I changed the first line of the Dockerfile from

    FROM circleci/php:7.4.12-cli-node

to

    FROM circleci/php:7.4.27-cli-node

And of course I also updated the version numbers in README.md and TAGS files.

Here is a screenshot of the new source image, where it defines the node version:
<img width="706" alt="Image Layer Details - circleci:php:7 4 27-cli-node | Docker Hub 2022-03-15 08-43-55" src="https://user-images.githubusercontent.com/922901/158321811-67589295-4e17-40aa-9204-5cce24ae3854.png">

