### PR TITLE
Make php,nginx, shell execute as nonroot users

### DIFF
--- a/nginx/1.17/Dockerfile
+++ b/nginx/1.17/Dockerfile
@@ -30,20 +30,24 @@ RUN CONFARGS=$(nginx -V 2>&1 | sed -n -e 's/^.*arguments: //p') \
 
 #### Make the nginx image and copy modules from builder
 
-FROM nginx:${NGINX_VERSION}-alpine
-
+FROM nginxinc/nginx-unprivileged:${NGINX_VERSION}-alpine
+ARG UID=101
 LABEL maintainer="wunder.io"
+USER root
 
 COPY --from=builder /ngx_http_echo_module.so /etc/nginx/modules/ngx_http_echo_module.so
 COPY modules/ngx_http_echo.conf /etc/nginx/modules/ngx_http_echo.conf
 
 RUN rm -rf /etc/nginx/conf.d/default.conf
 
-# ensure www-data user exists
-# 82 is the standard uid/gid for "www-data" in Alpine
-RUN set -x ; \
-	addgroup -g 82 -S www-data ; \
-	adduser -u 82 -D -S -s /sbin/nologin -G www-data www-data && exit 0 ; exit 1
+RUN rm -rf /etc/nginx/conf.d/default.conf \
+		&& touch /var/run/nginx.pid \
+		&& chown -R $UID:0 /var/run/nginx.pid
 
 RUN mkdir -p /var/www/html/web \
       && ln -s /var/www/html /app
+RUN adduser nginx www-data
+
+USER $UID
+
+CMD ["nginx", "-g", "daemon off;"]

--- a/nginx/1.19/Dockerfile
+++ b/nginx/1.19/Dockerfile
@@ -30,20 +30,22 @@ RUN CONFARGS=$(nginx -V 2>&1 | sed -n -e 's/^.*arguments: //p') \
 
 #### Make the nginx image and copy modules from builder
 
-FROM nginx:${NGINX_VERSION}-alpine
-
+FROM nginxinc/nginx-unprivileged:${NGINX_VERSION}-alpine
+ARG UID=101
 LABEL maintainer="wunder.io"
+USER root
 
 COPY --from=builder /ngx_http_echo_module.so /etc/nginx/modules/ngx_http_echo_module.so
 COPY modules/ngx_http_echo.conf /etc/nginx/modules/ngx_http_echo.conf
 
-RUN rm -rf /etc/nginx/conf.d/default.conf
-
-# ensure www-data user exists
-# 82 is the standard uid/gid for "www-data" in Alpine
-RUN set -x ; \
-	addgroup -g 82 -S www-data ; \
-	adduser -u 82 -D -S -s /sbin/nologin -G www-data www-data && exit 0 ; exit 1
+RUN rm -rf /etc/nginx/conf.d/default.conf \
+		&& touch /var/run/nginx.pid \
+		&& chown -R $UID:0 /var/run/nginx.pid
 
 RUN mkdir -p /var/www/html/web \
       && ln -s /var/www/html /app
+RUN adduser nginx www-data
+
+USER $UID
+
+CMD ["nginx", "-g", "daemon off;"]

--- a/nginx/1.21/Dockerfile
+++ b/nginx/1.21/Dockerfile
@@ -31,20 +31,22 @@ RUN CONFARGS=$(nginx -V 2>&1 | sed -n -e 's/^.*arguments: //p') \
 
 #### Make the nginx image and copy modules from builder
 
-FROM nginx:${NGINX_VERSION}-alpine
-
+FROM nginxinc/nginx-unprivileged:${NGINX_VERSION}-alpine
+ARG UID=101
 LABEL maintainer="wunder.io"
+USER root
 
 COPY --from=builder /ngx_http_echo_module.so /etc/nginx/modules/ngx_http_echo_module.so
 COPY modules/ngx_http_echo.conf /etc/nginx/modules/ngx_http_echo.conf
 
-RUN rm -rf /etc/nginx/conf.d/default.conf
-
-# ensure www-data user exists
-# 82 is the standard uid/gid for "www-data" in Alpine
-RUN set -x ; \
-	addgroup -g 82 -S www-data ; \
-	adduser -u 82 -D -S -s /sbin/nologin -G www-data www-data && exit 0 ; exit 1
+RUN rm -rf /etc/nginx/conf.d/default.conf \
+		&& touch /var/run/nginx.pid \
+		&& chown -R $UID:0 /var/run/nginx.pid
 
 RUN mkdir -p /var/www/html/web \
       && ln -s /var/www/html /app
+RUN adduser nginx www-data
+
+USER $UID
+
+CMD ["nginx", "-g", "daemon off;"]

--- a/php/7.2-fpm/Dockerfile
+++ b/php/7.2-fpm/Dockerfile
@@ -53,7 +53,9 @@ RUN set -ex; \
     mkdir -p -m a+w /app/web/sites/default/files; \
     mkdir -p -m a+w /app/private; \
     mkdir -p -m a+w /app/reference-data; \
-    chown -R www-data:www-data /app
+    chown -R www-data:www-data /app; \
+    # Allow fpm to write in config
+    chmod -R o+w /usr/local/etc
 
 WORKDIR /app/
 # Add composer executables to our path.

--- a/php/7.3-fpm/Dockerfile
+++ b/php/7.3-fpm/Dockerfile
@@ -53,7 +53,9 @@ RUN set -ex; \
     mkdir -p -m a+w /app/web/sites/default/files; \
     mkdir -p -m a+w /app/private; \
     mkdir -p -m a+w /app/reference-data; \
-    chown -R www-data:www-data /app
+    chown -R www-data:www-data /app; \
+    # Allow fpm to write in config
+    chmod -R o+w /usr/local/etc
 
 WORKDIR /app/
 # Add composer executables to our path.

--- a/php/7.4-fpm/Dockerfile
+++ b/php/7.4-fpm/Dockerfile
@@ -53,7 +53,9 @@ RUN set -ex; \
     mkdir -p -m a+w /app/web/sites/default/files; \
     mkdir -p -m a+w /app/private; \
     mkdir -p -m a+w /app/reference-data; \
-    chown -R www-data:www-data /app
+    chown -R www-data:www-data /app; \
+    # Allow fpm to write in config
+    chmod -R o+w /usr/local/etc
 
 WORKDIR /app/
 # Add composer executables to our path.

--- a/php/8.0-fpm/Dockerfile
+++ b/php/8.0-fpm/Dockerfile
@@ -56,7 +56,9 @@ RUN set -ex; \
     mkdir -p -m a+w /app/web/sites/default/files; \
     mkdir -p -m a+w /app/private; \
     mkdir -p -m a+w /app/reference-data; \
-    chown -R www-data:www-data /app
+    chown -R www-data:www-data /app; \
+    # Allow fpm to write in config
+    chmod -R o+w /usr/local/etc
 
 WORKDIR /app/
 # Add composer executables to our path.

--- a/shell/php-7.2/entrypoint.sh
+++ b/shell/php-7.2/entrypoint.sh
@@ -47,6 +47,8 @@ echo "www-admin:" | chpasswd
 mkdir ~www-admin/.ssh/
 env | grep -v HOME > ~www-admin/.ssh/environment
 
+adduser www-admin www-data
+
 # Trigger lagoon entrypoint scripts if present.
 if [ -f /lagoon/entrypoints.sh ] ; then /lagoon/entrypoints.sh ; fi
 

--- a/shell/php-7.3/entrypoint.sh
+++ b/shell/php-7.3/entrypoint.sh
@@ -47,6 +47,8 @@ echo "www-admin:" | chpasswd
 mkdir ~www-admin/.ssh/
 env | grep -v HOME > ~www-admin/.ssh/environment
 
+adduser www-admin www-data
+
 # Trigger lagoon entrypoint scripts if present.
 if [ -f /lagoon/entrypoints.sh ] ; then /lagoon/entrypoints.sh ; fi
 

--- a/shell/php-7.4/entrypoint.sh
+++ b/shell/php-7.4/entrypoint.sh
@@ -47,6 +47,8 @@ echo "www-admin:" | chpasswd
 mkdir ~www-admin/.ssh/
 env | grep -v HOME > ~www-admin/.ssh/environment
 
+adduser www-admin www-data
+
 # Trigger lagoon entrypoint scripts if present.
 if [ -f /lagoon/entrypoints.sh ] ; then /lagoon/entrypoints.sh ; fi
 

--- a/shell/php-8.0/entrypoint.sh
+++ b/shell/php-8.0/entrypoint.sh
@@ -47,6 +47,8 @@ echo "www-admin:" | chpasswd
 mkdir ~www-admin/.ssh/
 env | grep -v HOME > ~www-admin/.ssh/environment
 
+adduser www-admin www-data
+
 # Trigger lagoon entrypoint scripts if present.
 if [ -f /lagoon/entrypoints.sh ] ; then /lagoon/entrypoints.sh ; fi
 


### PR DESCRIPTION
Sets FPM, shell, nginx to run as non-root and have them all run in same user group

For testing php-fpm: add `USER www-data` directive at the end, like [in this commit](https://github.com/wunderio/drupal-project-k8s/blob/13e54ad58b4b14ab254d6fb9d6bffac7e214d242/silta/php.Dockerfile#L8)