### PR TITLE
Add support for alpine v.3.15

### DIFF
--- a/node/16-alpine/TAGS
+++ b/node/16-alpine/TAGS
@@ -1,4 +1,3 @@
 16-alpine-v0.1
 16-alpine-v0.1.0
-16-alpine-v3.14
 16-alpine-v3.15

--- a/node/16-alpine/TAGS
+++ b/node/16-alpine/TAGS
@@ -1,3 +1,4 @@
 16-alpine-v0.1
 16-alpine-v0.1.0
 16-alpine-v3.14
+16-alpine-v3.15


### PR DESCRIPTION
We need in our project because we need to add postgres client libraries for postgres 14, which became possible with 3.15:
https://pkgs.alpinelinux.org/packages?name=postgresql14*&branch=v3.15

Earlier alpine versions doesn't allow you to install postgres packages for a specific major version of postgres.