### PR TITLE
Silta container base image migration to Docker Hub

### DIFF
--- a/shell/php-7.2/Dockerfile
+++ b/shell/php-7.2/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for the Drupal container.
-FROM eu.gcr.io/silta-images/php:7.2-fpm-v0.1
+FROM wunderio/silta-php-fpm:7.2-fpm-v0.1
 
 # Switch back to root
 USER root

--- a/shell/php-7.3/Dockerfile
+++ b/shell/php-7.3/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for the Drupal container.
-FROM eu.gcr.io/silta-images/php:7.3-fpm-v0.1
+FROM wunderio/silta-php-fpm:7.3-fpm-v0.1
 
 # Switch back to root
 USER root

--- a/shell/php-7.4/Dockerfile
+++ b/shell/php-7.4/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for the Drupal container.
-FROM eu.gcr.io/silta-images/php:7.4-fpm-v0.1
+FROM wunderio/silta-php-fpm:7.4-fpm-v0.1
 
 # Switch back to root
 USER root

--- a/shell/php-8.0/Dockerfile
+++ b/shell/php-8.0/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for the Drupal container.
-FROM eu.gcr.io/silta-images/php:8.0-fpm-v0.1
+FROM wunderio/silta-php-fpm:8.0-fpm-v0.1
 
 # Workaround for base image
 # Xdebug: [Config] The setting 'xdebug.remote_enable' has been renamed, see the upgrading guide at https://xdebug.org/docs/upgrade_guide#changed-xdebug.remote_enable (See: https://xdebug.org/docs/errors#CFG-C-CHANGED)

--- a/varnish/README.md
+++ b/varnish/README.md
@@ -4,7 +4,7 @@ Docker container based on official varnish image.
 
 ## Usage
 
-docker pull eu.gcr.io/silta-images/varnish.
+docker pull wunderio/silta-varnish.
 
 ## Resources
 


### PR DESCRIPTION
Silta docker container images are being migrated from [Google Container Registry](https://eu.gcr.io/silta-images/) to [Docker Hub](https://hub.docker.com/u/wunderio).
This PR changes base image location to the new image registry and adjusts some image names.

Please review adjusted image paths and make sure this PR only changes relevant configuration files.

This pull request was created with https://github.com/wunderio/internal-mass-updater.