### PR TITLE
Specify GCLOUD_VERSION in circleci-php8.2-node18-composer2-v2 image

### DIFF
--- a/silta-cicd/circleci-php8.2-node18-composer2-v2/Dockerfile
+++ b/silta-cicd/circleci-php8.2-node18-composer2-v2/Dockerfile
@@ -15,6 +15,7 @@ RUN sudo wget -q https://github.com/drush-ops/drush-launcher/releases/download/$
 RUN sudo apt-get update && sudo apt-get install vim && sudo apt-get clean
 
 # Add gcloud CLI and kubectl
+ENV GCLOUD_VERSION 348.0.0-0
 RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | sudo tee -a /etc/apt/sources.list.d/google-cloud-sdk.list \
   && sudo apt-get install apt-transport-https ca-certificates \
   && curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key --keyring /usr/share/keyrings/cloud.google.gpg add - \


### PR DESCRIPTION
In our project we get an error from circleci during production deployment (develop works fine). The only difference I can find that theoretically could explain this is this missing line:

`ENV GCLOUD_VERSION 348.0.0-0`
