### PR TITLE
Change node16 -> node18 in node18 image's TAGS

### DIFF
--- a/silta-cicd/circleci-php8.2-node18-composer2-v2/TAGS
+++ b/silta-cicd/circleci-php8.2-node18-composer2-v2/TAGS
@@ -1,3 +1,3 @@
 circleci-php8.2.0-node18.12.1-composer2-v0.2
-circleci-php8.2-node16-composer2-v0.2
-circleci-php8.2-node16-composer2-v0.2.0
+circleci-php8.2-node18-composer2-v0.2
+circleci-php8.2-node18-composer2-v0.2.0


### PR DESCRIPTION
I guess we should use the correct node version in the TAGS file?