### PR TITLE
Trigger node image update (16.13->16.19)

### DIFF
--- a/.github/workflows/docker-images-testbuild.yml
+++ b/.github/workflows/docker-images-testbuild.yml
@@ -21,7 +21,7 @@ jobs:
             ${{ github.event.pull_request.base.sha }} ${{ github.event.pull_request.head.sha }} \
             | grep Dockerfile$ \
             | jq -Rsc '. / "\n" - [""]' )
-          echo "matrix=${dockerfile_list_json}" >> $GITHUB_OUTPUT
+          echo "matrix=${dockerfile_list_json}" > $GITHUB_OUTPUT
   
   test_build:
     name: Test build
@@ -38,4 +38,12 @@ jobs:
       - name: Building dockerfile
         run: |
           set -ex
-          docker build $(dirname ${{matrix.dockerfile}}) --file ${{matrix.dockerfile}}
+          tmpName="test-image-$RANDOM"
+          docker build $(dirname ${{matrix.dockerfile}}) --file ${{matrix.dockerfile}} --tag $tmpName
+          # Print versions
+          if [[ ${{matrix.dockerfile}} == *"silta-php"* ]]; then
+            docker run -t --rm $tmpName php -r 'echo "PHP " . PHP_VERSION;'
+          fi
+          if [[ ${{matrix.dockerfile}} == *"silta-node"* ]]; then
+            docker run -t --rm $tmpName node -v
+          fi

--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -28,7 +28,7 @@ jobs:
             $BUILD_CURRENT $BUILD_PREVIOUS \
             | grep TAGS$ \
             | jq -Rsc '. / "\n" - [""]' )
-          echo "matrix=${tagfile_list_json}" >> $GITHUB_OUTPUT
+          echo "matrix=${tagfile_list_json}" > $GITHUB_OUTPUT
 
   build_and_push_gcr:
     name: Build and push to GCR

--- a/silta-node/16-alpine/Dockerfile
+++ b/silta-node/16-alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16-alpine
+FROM node:16.19-alpine
 
 RUN apk add --no-cache openssh bash rsync curl
 

--- a/silta-node/16-alpine/TAGS
+++ b/silta-node/16-alpine/TAGS
@@ -1,3 +1,3 @@
 16-alpine-v0.1
-16-alpine-v0.1.1
+16-alpine-v0.1.2
 16-alpine-v3.15


### PR DESCRIPTION
- Define node 16 base image minor version so dependabot would suggest updates
- Node 16.13 to 16.19.1
- Output matrix changes for GA build process
- Print php or node versions in build process