### PR TITLE
Remove Azure CLI packaging

### DIFF
--- a/silta-cicd/circleci-php7.2-node14-composer1-v2/Dockerfile
+++ b/silta-cicd/circleci-php7.2-node14-composer1-v2/Dockerfile
@@ -39,9 +39,6 @@ RUN sudo apt install -y awscli git python3 \
   && chmod +x /tmp/aws-iam-authenticator \ 
   && sudo mv /tmp/aws-iam-authenticator /bin/aws-iam-authenticator
 
-# Install Azure cli
-RUN curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash
-
 # Install Helm 3
 ENV HELM_VERSION v3.6.3
 ENV FILENAME helm-${HELM_VERSION}-linux-amd64.tar.gz

--- a/silta-cicd/circleci-php7.2-node14-composer1-v2/TAGS
+++ b/silta-cicd/circleci-php7.2-node14-composer1-v2/TAGS
@@ -1,3 +1,3 @@
 circleci-php7.2.34-node14.15.2-composer1-v0.2
 circleci-php7.2-node14-composer1-v0.2
-circleci-php7.2-node14-composer1-v0.2.0
+circleci-php7.2-node14-composer1-v0.2.1

--- a/silta-cicd/circleci-php7.3-node12-composer1-v2/Dockerfile
+++ b/silta-cicd/circleci-php7.3-node12-composer1-v2/Dockerfile
@@ -34,9 +34,6 @@ RUN sudo apt install -y awscli git python3 \
   && chmod +x /tmp/aws-iam-authenticator \ 
   && sudo mv /tmp/aws-iam-authenticator /bin/aws-iam-authenticator
 
-# Install Azure cli
-RUN curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash
-
 # Install Helm 3
 ENV HELM_VERSION v3.6.3
 ENV FILENAME helm-${HELM_VERSION}-linux-amd64.tar.gz

--- a/silta-cicd/circleci-php7.3-node12-composer1-v2/TAGS
+++ b/silta-cicd/circleci-php7.3-node12-composer1-v2/TAGS
@@ -1,5 +1,5 @@
 circleci-php7.3.19-node12.18.2-composer1-v0.2
 circleci-php7.3-node12-composer1-v0.2
-circleci-php7.3-node12-composer1-v0.2.0
+circleci-php7.3-node12-composer1-v0.2.1
 v0.2
-v0.2.0
+v0.2.1

--- a/silta-cicd/circleci-php7.3-node14-composer1-v2/Dockerfile
+++ b/silta-cicd/circleci-php7.3-node14-composer1-v2/Dockerfile
@@ -39,9 +39,6 @@ RUN sudo apt install -y awscli git python3 \
   && chmod +x /tmp/aws-iam-authenticator \ 
   && sudo mv /tmp/aws-iam-authenticator /bin/aws-iam-authenticator
 
-# Install Azure cli
-RUN curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash
-
 # Install Helm 3
 ENV HELM_VERSION v3.6.3
 ENV FILENAME helm-${HELM_VERSION}-linux-amd64.tar.gz

--- a/silta-cicd/circleci-php7.3-node14-composer1-v2/TAGS
+++ b/silta-cicd/circleci-php7.3-node14-composer1-v2/TAGS
@@ -1,3 +1,3 @@
 circleci-php7.3.23-node14.15.0-composer1-v0.2
 circleci-php7.3-node14-composer1-v0.2
-circleci-php7.3-node14-composer1-v0.2.0
+circleci-php7.3-node14-composer1-v0.2.1

--- a/silta-cicd/circleci-php7.3-node14-composer2-v2/Dockerfile
+++ b/silta-cicd/circleci-php7.3-node14-composer2-v2/Dockerfile
@@ -34,9 +34,6 @@ RUN sudo apt install -y awscli git python3 \
   && chmod +x /tmp/aws-iam-authenticator \ 
   && sudo mv /tmp/aws-iam-authenticator /bin/aws-iam-authenticator
 
-# Install Azure cli
-RUN curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash
-
 # Install Helm 3
 ENV HELM_VERSION v3.6.3
 ENV FILENAME helm-${HELM_VERSION}-linux-amd64.tar.gz

--- a/silta-cicd/circleci-php7.3-node14-composer2-v2/TAGS
+++ b/silta-cicd/circleci-php7.3-node14-composer2-v2/TAGS
@@ -1,3 +1,3 @@
 circleci-php7.3.23-node14.15.0-composer2-v0.2
 circleci-php7.3-node14-composer2-v0.2
-circleci-php7.3-node14-composer2-v0.2.0
+circleci-php7.3-node14-composer2-v0.2.1

--- a/silta-cicd/circleci-php7.4-node14-composer1-v2/Dockerfile
+++ b/silta-cicd/circleci-php7.4-node14-composer1-v2/Dockerfile
@@ -39,9 +39,6 @@ RUN sudo apt install -y awscli git python3 \
   && chmod +x /tmp/aws-iam-authenticator \ 
   && sudo mv /tmp/aws-iam-authenticator /bin/aws-iam-authenticator
 
-# Install Azure cli
-RUN curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash
-
 # Install Helm 3
 ENV HELM_VERSION v3.6.3
 ENV FILENAME helm-${HELM_VERSION}-linux-amd64.tar.gz

--- a/silta-cicd/circleci-php7.4-node14-composer1-v2/TAGS
+++ b/silta-cicd/circleci-php7.4-node14-composer1-v2/TAGS
@@ -1,3 +1,3 @@
 circleci-php7.4.12-node14.15.1-composer1-v0.2
 circleci-php7.4-node14-composer1-v0.2
-circleci-php7.4-node14-composer1-v0.2.0
+circleci-php7.4-node14-composer1-v0.2.1

--- a/silta-cicd/circleci-php7.4-node14-composer2-v2/Dockerfile
+++ b/silta-cicd/circleci-php7.4-node14-composer2-v2/Dockerfile
@@ -34,9 +34,6 @@ RUN sudo apt install -y awscli git python3 \
   && chmod +x /tmp/aws-iam-authenticator \ 
   && sudo mv /tmp/aws-iam-authenticator /bin/aws-iam-authenticator
 
-# Install Azure cli
-RUN curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash
-
 # Install Helm 3
 ENV HELM_VERSION v3.6.3
 ENV FILENAME helm-${HELM_VERSION}-linux-amd64.tar.gz

--- a/silta-cicd/circleci-php7.4-node14-composer2-v2/TAGS
+++ b/silta-cicd/circleci-php7.4-node14-composer2-v2/TAGS
@@ -1,3 +1,3 @@
 circleci-php7.4.12-node14.15.1-composer2-v0.2
 circleci-php7.4-node14-composer2-v0.2
-circleci-php7.4-node14-composer2-v0.2.0
+circleci-php7.4-node14-composer2-v0.2.1

--- a/silta-cicd/circleci-php7.4-node16-composer1-v2/Dockerfile
+++ b/silta-cicd/circleci-php7.4-node16-composer1-v2/Dockerfile
@@ -39,9 +39,6 @@ RUN sudo apt install -y awscli git python3 \
   && chmod +x /tmp/aws-iam-authenticator \
   && sudo mv /tmp/aws-iam-authenticator /bin/aws-iam-authenticator
 
-# Install Azure cli
-RUN curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash
-
 # Install Helm 3
 ENV HELM_VERSION v3.6.3
 ENV FILENAME helm-${HELM_VERSION}-linux-amd64.tar.gz

--- a/silta-cicd/circleci-php7.4-node16-composer1-v2/TAGS
+++ b/silta-cicd/circleci-php7.4-node16-composer1-v2/TAGS
@@ -1,3 +1,3 @@
 circleci-php7.4.27-node16.13.1-composer1-v0.2
 circleci-php7.4-node16-composer1-v0.2
-circleci-php7.4-node16-composer1-v0.2.0
+circleci-php7.4-node16-composer1-v0.2.1

--- a/silta-cicd/circleci-php8.0-node14-composer2-v2/Dockerfile
+++ b/silta-cicd/circleci-php8.0-node14-composer2-v2/Dockerfile
@@ -33,9 +33,6 @@ RUN sudo apt install -y awscli git python3 \
   && chmod +x /tmp/aws-iam-authenticator \ 
   && sudo mv /tmp/aws-iam-authenticator /bin/aws-iam-authenticator
 
-# Install Azure cli
-RUN curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash
-
 # Install Helm 3
 ENV HELM_VERSION v3.6.3
 ENV FILENAME helm-${HELM_VERSION}-linux-amd64.tar.gz

--- a/silta-cicd/circleci-php8.0-node14-composer2-v2/TAGS
+++ b/silta-cicd/circleci-php8.0-node14-composer2-v2/TAGS
@@ -1,3 +1,3 @@
 circleci-php8.0.1-node14.15.4-composer2-v0.2
 circleci-php8.0-node14-composer2-v0.2
-circleci-php8.0-node14-composer2-v0.2.0
+circleci-php8.0-node14-composer2-v0.2.1

--- a/silta-cicd/circleci-php8.0-node16-composer2-v2/Dockerfile
+++ b/silta-cicd/circleci-php8.0-node16-composer2-v2/Dockerfile
@@ -35,9 +35,6 @@ RUN sudo apt install -y awscli git python3 \
   && chmod +x /tmp/aws-iam-authenticator \ 
   && sudo mv /tmp/aws-iam-authenticator /bin/aws-iam-authenticator
 
-# Install Azure cli
-RUN curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash
-
 # Install Helm 3
 ENV HELM_VERSION v3.6.3
 ENV FILENAME helm-${HELM_VERSION}-linux-amd64.tar.gz

--- a/silta-cicd/circleci-php8.0-node16-composer2-v2/TAGS
+++ b/silta-cicd/circleci-php8.0-node16-composer2-v2/TAGS
@@ -1,3 +1,3 @@
 circleci-php8.0.13-node16.13.0-composer2-v0.2
 circleci-php8.0-node16-composer2-v0.2
-circleci-php8.0-node16-composer2-v0.2.0
+circleci-php8.0-node16-composer2-v0.2.1

--- a/silta-cicd/circleci-php8.1-node16-composer2-v2/Dockerfile
+++ b/silta-cicd/circleci-php8.1-node16-composer2-v2/Dockerfile
@@ -34,9 +34,6 @@ RUN sudo apt install -y awscli git python3 \
   && chmod +x /tmp/aws-iam-authenticator \ 
   && sudo mv /tmp/aws-iam-authenticator /bin/aws-iam-authenticator
 
-# Install Azure cli
-RUN curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash
-
 # Install Helm 3
 ENV HELM_VERSION v3.6.3
 ENV FILENAME helm-${HELM_VERSION}-linux-amd64.tar.gz

--- a/silta-cicd/circleci-php8.1-node16-composer2-v2/TAGS
+++ b/silta-cicd/circleci-php8.1-node16-composer2-v2/TAGS
@@ -1,3 +1,3 @@
 circleci-php8.1.7-node16.15.1-composer2-v0.2
 circleci-php8.1-node16-composer2-v0.2
-circleci-php8.1-node16-composer2-v0.2.0
+circleci-php8.1-node16-composer2-v0.2.1

--- a/silta-cicd/circleci-php8.2-node18-composer2-v2/Dockerfile
+++ b/silta-cicd/circleci-php8.2-node18-composer2-v2/Dockerfile
@@ -33,9 +33,6 @@ RUN sudo apt install -y awscli git python3 \
   && chmod +x /tmp/aws-iam-authenticator \ 
   && sudo mv /tmp/aws-iam-authenticator /bin/aws-iam-authenticator
 
-# Install Azure cli
-RUN curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash
-
 # Install Helm 3
 ENV HELM_VERSION v3.6.3
 ENV FILENAME helm-${HELM_VERSION}-linux-amd64.tar.gz

--- a/silta-cicd/circleci-php8.2-node18-composer2-v2/TAGS
+++ b/silta-cicd/circleci-php8.2-node18-composer2-v2/TAGS
@@ -1,3 +1,3 @@
 circleci-php8.2.0-node18.12.1-composer2-v0.2
 circleci-php8.2-node18-composer2-v0.2
-circleci-php8.2-node18-composer2-v0.2.0
+circleci-php8.2-node18-composer2-v0.2.1


### PR DESCRIPTION
Removes Azure CLI from CI/CD builder images.

Merge after [this PR](https://github.com/wunderio/silta-cli/pull/44) is deployed.