### PR TITLE
sudo removal

### DIFF
--- a/silta-php-shell/php-7.2/Dockerfile
+++ b/silta-php-shell/php-7.2/Dockerfile
@@ -15,7 +15,4 @@ COPY entrypoint.sh /
 # Won't use buildkit yet
 RUN chmod 755 /etc/ssh/gitauth_keys.sh
 
-# Provide sudo access to www-data user
-RUN apk add sudo && echo '%wheel ALL = (ALL) NOPASSWD: ALL' > /etc/sudoers.d/wheel && adduser www-data wheel
-
 ENTRYPOINT ["/entrypoint.sh"]

--- a/silta-php-shell/php-7.3/Dockerfile
+++ b/silta-php-shell/php-7.3/Dockerfile
@@ -15,7 +15,4 @@ COPY entrypoint.sh /
 # Won't use buildkit yet
 RUN chmod 755 /etc/ssh/gitauth_keys.sh
 
-# Provide sudo access to www-data user
-RUN apk add sudo && echo '%wheel ALL = (ALL) NOPASSWD: ALL' > /etc/sudoers.d/wheel && adduser www-data wheel
-
 ENTRYPOINT ["/entrypoint.sh"]

--- a/silta-php-shell/php-7.4/Dockerfile
+++ b/silta-php-shell/php-7.4/Dockerfile
@@ -15,7 +15,4 @@ COPY entrypoint.sh /
 # Won't use buildkit yet
 RUN chmod 755 /etc/ssh/gitauth_keys.sh
 
-# Provide sudo access to www-data user
-RUN apk add sudo && echo '%wheel ALL = (ALL) NOPASSWD: ALL' > /etc/sudoers.d/wheel && adduser www-data wheel
-
 ENTRYPOINT ["/entrypoint.sh"]

--- a/silta-php-shell/php-8.0/Dockerfile
+++ b/silta-php-shell/php-8.0/Dockerfile
@@ -15,7 +15,4 @@ COPY entrypoint.sh /
 # Won't use buildkit yet
 RUN chmod 755 /etc/ssh/gitauth_keys.sh
 
-# Provide sudo access to www-data user
-RUN apk add sudo && echo '%wheel ALL = (ALL) NOPASSWD: ALL' > /etc/sudoers.d/wheel && adduser www-data wheel
-
 ENTRYPOINT ["/entrypoint.sh"]

--- a/silta-php-shell/php-8.1/Dockerfile
+++ b/silta-php-shell/php-8.1/Dockerfile
@@ -15,7 +15,4 @@ COPY entrypoint.sh /
 # Won't use buildkit yet
 RUN chmod 755 /etc/ssh/gitauth_keys.sh
 
-# Provide sudo access to www-data user
-RUN apk add sudo && echo '%wheel ALL = (ALL) NOPASSWD: ALL' > /etc/sudoers.d/wheel && adduser www-data wheel
-
 ENTRYPOINT ["/entrypoint.sh"]

--- a/silta-php-shell/php-8.2/Dockerfile
+++ b/silta-php-shell/php-8.2/Dockerfile
@@ -15,7 +15,4 @@ COPY entrypoint.sh /
 # Won't use buildkit yet
 RUN chmod 755 /etc/ssh/gitauth_keys.sh
 
-# Provide sudo access to www-data user
-RUN apk add sudo && echo '%wheel ALL = (ALL) NOPASSWD: ALL' > /etc/sudoers.d/wheel && adduser www-data wheel
-
 ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
Unnecessary `sudo` functionality removed, `TAGS` files are not adjusted as images were pushed directly to image registry.