### PR TITLE
CI/CD: Moving base tag from v0.1 to v0.2 images

### DIFF
--- a/silta-cicd/circleci-php7.2-node14-composer1-v1/TAGS
+++ b/silta-cicd/circleci-php7.2-node14-composer1-v1/TAGS
@@ -1,4 +1,3 @@
-circleci-php7.2-node14-composer1
 circleci-php7.2.34-node14.15.2-composer1
 circleci-php7.2-node14-composer1-v0.1
 circleci-php7.2-node14-composer1-v0.1.114

--- a/silta-cicd/circleci-php7.2-node14-composer1/TAGS
+++ b/silta-cicd/circleci-php7.2-node14-composer1/TAGS
@@ -1,3 +1,4 @@
 circleci-php7.2.34-node14.15.2-composer1-v0.2
+circleci-php7.2-node14-composer1
 circleci-php7.2-node14-composer1-v0.2
 circleci-php7.2-node14-composer1-v0.2.2

--- a/silta-cicd/circleci-php7.3-node12-composer1-v1/TAGS
+++ b/silta-cicd/circleci-php7.3-node12-composer1-v1/TAGS
@@ -1,4 +1,3 @@
-circleci-php7.3-node12-composer1
 circleci-php7.3.19-node12.18.2-composer1
 circleci-php7.3-node12-composer1-v0.1
 circleci-php7.3-node12-composer1-v0.1.114

--- a/silta-cicd/circleci-php7.3-node12-composer1/TAGS
+++ b/silta-cicd/circleci-php7.3-node12-composer1/TAGS
@@ -1,4 +1,5 @@
 circleci-php7.3.19-node12.18.2-composer1-v0.2
+circleci-php7.3-node12-composer1
 circleci-php7.3-node12-composer1-v0.2
 circleci-php7.3-node12-composer1-v0.2.2
 v0.2

--- a/silta-cicd/circleci-php7.3-node14-composer1-v1/TAGS
+++ b/silta-cicd/circleci-php7.3-node14-composer1-v1/TAGS
@@ -1,4 +1,3 @@
-circleci-php7.3-node14-composer1
 circleci-php7.3.23-node14.15.0-composer1
 circleci-php7.3-node14-composer1-v0.1
 circleci-php7.3-node14-composer1-v0.1.11

--- a/silta-cicd/circleci-php7.3-node14-composer1/TAGS
+++ b/silta-cicd/circleci-php7.3-node14-composer1/TAGS
@@ -1,3 +1,4 @@
 circleci-php7.3.23-node14.15.0-composer1-v0.2
+circleci-php7.3-node14-composer1
 circleci-php7.3-node14-composer1-v0.2
 circleci-php7.3-node14-composer1-v0.2.2

--- a/silta-cicd/circleci-php7.3-node14-composer2-v1/TAGS
+++ b/silta-cicd/circleci-php7.3-node14-composer2-v1/TAGS
@@ -1,4 +1,3 @@
-circleci-php7.3-node14-composer2
 circleci-php7.3.23-node14.15.0-composer2
 circleci-php7.3-node14-composer2-v0.1
 circleci-php7.3-node14-composer2-v0.1.11

--- a/silta-cicd/circleci-php7.3-node14-composer2/TAGS
+++ b/silta-cicd/circleci-php7.3-node14-composer2/TAGS
@@ -1,3 +1,4 @@
 circleci-php7.3.23-node14.15.0-composer2-v0.2
+circleci-php7.3-node14-composer2
 circleci-php7.3-node14-composer2-v0.2
 circleci-php7.3-node14-composer2-v0.2.2

--- a/silta-cicd/circleci-php7.4-node14-composer1-v1/TAGS
+++ b/silta-cicd/circleci-php7.4-node14-composer1-v1/TAGS
@@ -1,4 +1,3 @@
-circleci-php7.4-node14-composer1
 circleci-php7.4.12-node14.15.1-composer1
 circleci-php7.4-node14-composer1-v0.1
 circleci-php7.4-node14-composer1-v0.1.11

--- a/silta-cicd/circleci-php7.4-node14-composer1/TAGS
+++ b/silta-cicd/circleci-php7.4-node14-composer1/TAGS
@@ -1,3 +1,4 @@
 circleci-php7.4.12-node14.15.1-composer1-v0.2
+circleci-php7.4-node14-composer1
 circleci-php7.4-node14-composer1-v0.2
 circleci-php7.4-node14-composer1-v0.2.2

--- a/silta-cicd/circleci-php7.4-node14-composer2-v1/TAGS
+++ b/silta-cicd/circleci-php7.4-node14-composer2-v1/TAGS
@@ -1,4 +1,3 @@
-circleci-php7.4-node14-composer2
 circleci-php7.4.12-node14.15.1-composer2
 circleci-php7.4-node14-composer2-v0.1
 circleci-php7.4-node14-composer2-v0.1.12

--- a/silta-cicd/circleci-php7.4-node14-composer2/TAGS
+++ b/silta-cicd/circleci-php7.4-node14-composer2/TAGS
@@ -1,3 +1,4 @@
 circleci-php7.4.12-node14.15.1-composer2-v0.2
+circleci-php7.4-node14-composer2
 circleci-php7.4-node14-composer2-v0.2
 circleci-php7.4-node14-composer2-v0.2.2

--- a/silta-cicd/circleci-php7.4-node16-composer1-v1/TAGS
+++ b/silta-cicd/circleci-php7.4-node16-composer1-v1/TAGS
@@ -1,4 +1,3 @@
-circleci-php7.4-node16-composer1
 circleci-php7.4.27-node16.13.1-composer1
 circleci-php7.4-node16-composer1-v0.1
 circleci-php7.4-node16-composer1-v0.1.11

--- a/silta-cicd/circleci-php7.4-node16-composer1/TAGS
+++ b/silta-cicd/circleci-php7.4-node16-composer1/TAGS
@@ -1,3 +1,4 @@
 circleci-php7.4.27-node16.13.1-composer1-v0.2
+circleci-php7.4-node16-composer1
 circleci-php7.4-node16-composer1-v0.2
 circleci-php7.4-node16-composer1-v0.2.2

--- a/silta-cicd/circleci-php8.0-node14-composer2-v1/TAGS
+++ b/silta-cicd/circleci-php8.0-node14-composer2-v1/TAGS
@@ -1,4 +1,3 @@
-circleci-php8.0-node14-composer2
 circleci-php8.0.1-node14.15.4-composer2
 circleci-php8.0-node14-composer2-v0.1
 circleci-php8.0-node14-composer2-v0.1.10

--- a/silta-cicd/circleci-php8.0-node14-composer2/TAGS
+++ b/silta-cicd/circleci-php8.0-node14-composer2/TAGS
@@ -1,3 +1,4 @@
 circleci-php8.0.1-node14.15.4-composer2-v0.2
+circleci-php8.0-node14-composer2
 circleci-php8.0-node14-composer2-v0.2
 circleci-php8.0-node14-composer2-v0.2.2

--- a/silta-cicd/circleci-php8.0-node16-composer2-v1/TAGS
+++ b/silta-cicd/circleci-php8.0-node16-composer2-v1/TAGS
@@ -1,4 +1,3 @@
-circleci-php8.0-node16-composer2
 circleci-php8.0.13-node16.13.0-composer2
 circleci-php8.0-node16-composer2-v0.1
 circleci-php8.0-node16-composer2-v0.1.6

--- a/silta-cicd/circleci-php8.0-node16-composer2/TAGS
+++ b/silta-cicd/circleci-php8.0-node16-composer2/TAGS
@@ -1,3 +1,4 @@
 circleci-php8.0.13-node16.13.0-composer2-v0.2
+circleci-php8.0-node16-composer2
 circleci-php8.0-node16-composer2-v0.2
 circleci-php8.0-node16-composer2-v0.2.2

--- a/silta-cicd/circleci-php8.1-node16-composer2-v1/TAGS
+++ b/silta-cicd/circleci-php8.1-node16-composer2-v1/TAGS
@@ -1,4 +1,3 @@
-circleci-php8.1-node16-composer2
 circleci-php8.1.7-node16.15.1-composer2
 circleci-php8.1-node16-composer2-v0.1
 circleci-php8.1-node16-composer2-v0.1.2

--- a/silta-cicd/circleci-php8.1-node16-composer2/TAGS
+++ b/silta-cicd/circleci-php8.1-node16-composer2/TAGS
@@ -1,3 +1,4 @@
 circleci-php8.1.7-node16.15.1-composer2-v0.2
+circleci-php8.1-node16-composer2
 circleci-php8.1-node16-composer2-v0.2
 circleci-php8.1-node16-composer2-v0.2.2

--- a/silta-cicd/circleci-php8.2-node18-composer2/TAGS
+++ b/silta-cicd/circleci-php8.2-node18-composer2/TAGS
@@ -1,3 +1,4 @@
 circleci-php8.2.0-node18.12.1-composer2-v0.2
+circleci-php8.2-node18-composer2
 circleci-php8.2-node18-composer2-v0.2
 circleci-php8.2-node18-composer2-v0.2.2


### PR DESCRIPTION
Moving cicd image base tag from v0.1 to v0.2 to retain compatibility with projects that are not using `v0.2`