### PR TITLE
Node: umask and entrypoint script support

### DIFF
--- a/silta-node/12-alpine/Dockerfile
+++ b/silta-node/12-alpine/Dockerfile
@@ -9,6 +9,7 @@ RUN mkdir /etc/ssh/keys
 # Copy scripts
 COPY gitauth_keys.sh /etc/ssh/
 COPY entrypoint.sh /
+COPY silta /silta
 
 ENTRYPOINT ["/entrypoint.sh"]
 

--- a/silta-node/12-alpine/TAGS
+++ b/silta-node/12-alpine/TAGS
@@ -1,2 +1,2 @@
 12-alpine-v0.1
-12-alpine-v0.1.2
+12-alpine-v0.1.3

--- a/silta-node/12-alpine/entrypoint.sh
+++ b/silta-node/12-alpine/entrypoint.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# Trigger silta entrypoint scripts if present.
+if [ -f /silta/entrypoint.sh ] ; then /silta/entrypoint.sh ; fi
+
 if [[ -v GITAUTH_URL ]]; then
 
     if [[ ! -f /etc/ssh/keys/ssh_host_rsa_key ]]; then
@@ -39,9 +42,8 @@ OUTSIDE_COLLABORATORS=${OUTSIDE_COLLABORATORS}
 EOF
 
     env > /etc/environment
-    addgroup www-admin
     # We add -D to make it non-interactive, but then the user is locked out.
-    adduser www-admin -D -G www-admin -s /bin/bash -h /app
+    adduser www-admin -D -G node -s /bin/bash -h /app
     # So set an empty password after the user is created.
     echo "www-admin:" | chpasswd
 
@@ -49,6 +51,8 @@ EOF
     mkdir ~www-admin/.ssh/
     env | grep -v HOME > ~www-admin/.ssh/environment
 
+    echo "umask 0002" >> ~www-admin/.profile
+    
     # run SSH server
     /usr/sbin/sshd -E /proc/self/fd/2
 fi

--- a/silta-node/12-alpine/silta/.bashrc
+++ b/silta-node/12-alpine/silta/.bashrc
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+source /silta/entrypoints/00-umask.sh
+
+if [ "${PS1-}" ]; then
+    PS1="\w$ "
+fi

--- a/silta-node/12-alpine/silta/entrypoint.sh
+++ b/silta-node/12-alpine/silta/entrypoint.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env sh
+set -e
+
+## Run startup scripts
+for f in $(dirname "$0")/entrypoints/*.sh; do
+  if [ -r $f ]; then
+    . "$f"
+  fi
+done

--- a/silta-node/12-alpine/silta/entrypoints/00-umask.sh
+++ b/silta-node/12-alpine/silta/entrypoints/00-umask.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env sh
+
+umask 002

--- a/silta-node/14-alpine/Dockerfile
+++ b/silta-node/14-alpine/Dockerfile
@@ -9,6 +9,7 @@ RUN mkdir /etc/ssh/keys
 # Copy scripts
 COPY gitauth_keys.sh /etc/ssh/
 COPY entrypoint.sh /
+COPY silta /silta
 
 ENTRYPOINT ["/entrypoint.sh"]
 

--- a/silta-node/14-alpine/TAGS
+++ b/silta-node/14-alpine/TAGS
@@ -1,2 +1,2 @@
 14-alpine-v0.1
-14-alpine-v0.1.2
+14-alpine-v0.1.3

--- a/silta-node/14-alpine/entrypoint.sh
+++ b/silta-node/14-alpine/entrypoint.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# Trigger silta entrypoint scripts if present.
+if [ -f /silta/entrypoint.sh ] ; then /silta/entrypoint.sh ; fi
+
 if [[ -v GITAUTH_URL ]]; then
 
     if [[ ! -f /etc/ssh/keys/ssh_host_rsa_key ]]; then
@@ -39,9 +42,8 @@ OUTSIDE_COLLABORATORS=${OUTSIDE_COLLABORATORS}
 EOF
 
     env > /etc/environment
-    addgroup www-admin
     # We add -D to make it non-interactive, but then the user is locked out.
-    adduser www-admin -D -G www-admin -s /bin/bash -h /app
+    adduser www-admin -D -G node -s /bin/bash -h /app
     # So set an empty password after the user is created.
     echo "www-admin:" | chpasswd
 
@@ -49,6 +51,8 @@ EOF
     mkdir ~www-admin/.ssh/
     env | grep -v HOME > ~www-admin/.ssh/environment
 
+    echo "umask 0002" >> ~www-admin/.profile
+    
     # run SSH server
     /usr/sbin/sshd -E /proc/self/fd/2
 fi

--- a/silta-node/14-alpine/silta/.bashrc
+++ b/silta-node/14-alpine/silta/.bashrc
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+source /silta/entrypoints/00-umask.sh
+
+if [ "${PS1-}" ]; then
+    PS1="\w$ "
+fi

--- a/silta-node/14-alpine/silta/entrypoint.sh
+++ b/silta-node/14-alpine/silta/entrypoint.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env sh
+set -e
+
+## Run startup scripts
+for f in $(dirname "$0")/entrypoints/*.sh; do
+  if [ -r $f ]; then
+    . "$f"
+  fi
+done

--- a/silta-node/14-alpine/silta/entrypoints/00-umask.sh
+++ b/silta-node/14-alpine/silta/entrypoints/00-umask.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env sh
+
+umask 002

--- a/silta-node/16-alpine/Dockerfile
+++ b/silta-node/16-alpine/Dockerfile
@@ -9,6 +9,7 @@ RUN mkdir /etc/ssh/keys
 # Copy scripts
 COPY gitauth_keys.sh /etc/ssh/
 COPY entrypoint.sh /
+COPY silta /silta
 
 ENTRYPOINT ["/entrypoint.sh"]
 

--- a/silta-node/16-alpine/TAGS
+++ b/silta-node/16-alpine/TAGS
@@ -1,2 +1,2 @@
 16-alpine-v0.1
-16-alpine-v0.1.3
+16-alpine-v0.1.4

--- a/silta-node/16-alpine/entrypoint.sh
+++ b/silta-node/16-alpine/entrypoint.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# Trigger silta entrypoint scripts if present.
+if [ -f /silta/entrypoint.sh ] ; then /silta/entrypoint.sh ; fi
+
 if [[ -v GITAUTH_URL ]]; then
 
     if [[ ! -f /etc/ssh/keys/ssh_host_rsa_key ]]; then
@@ -39,9 +42,8 @@ OUTSIDE_COLLABORATORS=${OUTSIDE_COLLABORATORS}
 EOF
 
     env > /etc/environment
-    addgroup www-admin
     # We add -D to make it non-interactive, but then the user is locked out.
-    adduser www-admin -D -G www-admin -s /bin/bash -h /app
+    adduser www-admin -D -G node -s /bin/bash -h /app
     # So set an empty password after the user is created.
     echo "www-admin:" | chpasswd
 
@@ -49,6 +51,8 @@ EOF
     mkdir ~www-admin/.ssh/
     env | grep -v HOME > ~www-admin/.ssh/environment
 
+    echo "umask 0002" >> ~www-admin/.profile
+    
     # run SSH server
     /usr/sbin/sshd -E /proc/self/fd/2
 fi

--- a/silta-node/16-alpine/silta/.bashrc
+++ b/silta-node/16-alpine/silta/.bashrc
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+source /silta/entrypoints/00-umask.sh
+
+if [ "${PS1-}" ]; then
+    PS1="\w$ "
+fi

--- a/silta-node/16-alpine/silta/entrypoint.sh
+++ b/silta-node/16-alpine/silta/entrypoint.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env sh
+set -e
+
+## Run startup scripts
+for f in $(dirname "$0")/entrypoints/*.sh; do
+  if [ -r $f ]; then
+    . "$f"
+  fi
+done

--- a/silta-node/16-alpine/silta/entrypoints/00-umask.sh
+++ b/silta-node/16-alpine/silta/entrypoints/00-umask.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env sh
+
+umask 002

--- a/silta-node/18-alpine/Dockerfile
+++ b/silta-node/18-alpine/Dockerfile
@@ -9,6 +9,7 @@ RUN mkdir /etc/ssh/keys
 # Copy scripts
 COPY gitauth_keys.sh /etc/ssh/
 COPY entrypoint.sh /
+COPY silta /silta
 
 ENTRYPOINT ["/entrypoint.sh"]
 

--- a/silta-node/18-alpine/TAGS
+++ b/silta-node/18-alpine/TAGS
@@ -1,2 +1,2 @@
 18-alpine-v0.1
-18-alpine-v0.1.2
+18-alpine-v0.1.3

--- a/silta-node/18-alpine/entrypoint.sh
+++ b/silta-node/18-alpine/entrypoint.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# Trigger silta entrypoint scripts if present.
+if [ -f /silta/entrypoint.sh ] ; then /silta/entrypoint.sh ; fi
+
 if [[ -v GITAUTH_URL ]]; then
 
     if [[ ! -f /etc/ssh/keys/ssh_host_rsa_key ]]; then
@@ -39,15 +42,16 @@ OUTSIDE_COLLABORATORS=${OUTSIDE_COLLABORATORS}
 EOF
 
     env > /etc/environment
-    addgroup www-admin
     # We add -D to make it non-interactive, but then the user is locked out.
-    adduser www-admin -D -G www-admin -s /bin/bash -h /app
+    adduser www-admin -D -G node -s /bin/bash -h /app
     # So set an empty password after the user is created.
     echo "www-admin:" | chpasswd
 
     # Pass environment variables down to container, so SSH can pick it up and drush commands work too.
     mkdir ~www-admin/.ssh/
     env | grep -v HOME > ~www-admin/.ssh/environment
+
+    echo "umask 0002" >> ~www-admin/.profile
 
     # run SSH server
     /usr/sbin/sshd -E /proc/self/fd/2

--- a/silta-node/18-alpine/silta/.bashrc
+++ b/silta-node/18-alpine/silta/.bashrc
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+source /silta/entrypoints/00-umask.sh
+
+if [ "${PS1-}" ]; then
+    PS1="\w$ "
+fi

--- a/silta-node/18-alpine/silta/entrypoint.sh
+++ b/silta-node/18-alpine/silta/entrypoint.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env sh
+set -e
+
+## Run startup scripts
+for f in $(dirname "$0")/entrypoints/*.sh; do
+  if [ -r $f ]; then
+    . "$f"
+  fi
+done

--- a/silta-node/18-alpine/silta/entrypoints/00-umask.sh
+++ b/silta-node/18-alpine/silta/entrypoints/00-umask.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env sh
+
+umask 002

--- a/silta-node/20-alpine/Dockerfile
+++ b/silta-node/20-alpine/Dockerfile
@@ -9,6 +9,7 @@ RUN mkdir /etc/ssh/keys
 # Copy scripts
 COPY gitauth_keys.sh /etc/ssh/
 COPY entrypoint.sh /
+COPY silta /silta
 
 ENTRYPOINT ["/entrypoint.sh"]
 

--- a/silta-node/20-alpine/TAGS
+++ b/silta-node/20-alpine/TAGS
@@ -1,2 +1,2 @@
 20-alpine-v0.1
-20-alpine-v0.1.0
+20-alpine-v0.1.1

--- a/silta-node/20-alpine/entrypoint.sh
+++ b/silta-node/20-alpine/entrypoint.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# Trigger silta entrypoint scripts if present.
+if [ -f /silta/entrypoint.sh ] ; then /silta/entrypoint.sh ; fi
+
 if [[ -v GITAUTH_URL ]]; then
 
     if [[ ! -f /etc/ssh/keys/ssh_host_rsa_key ]]; then
@@ -39,15 +42,16 @@ OUTSIDE_COLLABORATORS=${OUTSIDE_COLLABORATORS}
 EOF
 
     env > /etc/environment
-    addgroup www-admin
     # We add -D to make it non-interactive, but then the user is locked out.
-    adduser www-admin -D -G www-admin -s /bin/bash -h /app
+    adduser www-admin -D -G node -s /bin/bash -h /app
     # So set an empty password after the user is created.
     echo "www-admin:" | chpasswd
 
     # Pass environment variables down to container, so SSH can pick it up and drush commands work too.
     mkdir ~www-admin/.ssh/
     env | grep -v HOME > ~www-admin/.ssh/environment
+
+    echo "umask 0002" >> ~www-admin/.profile
 
     # run SSH server
     /usr/sbin/sshd -E /proc/self/fd/2

--- a/silta-node/20-alpine/silta/.bashrc
+++ b/silta-node/20-alpine/silta/.bashrc
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+source /silta/entrypoints/00-umask.sh
+
+if [ "${PS1-}" ]; then
+    PS1="\w$ "
+fi

--- a/silta-node/20-alpine/silta/entrypoint.sh
+++ b/silta-node/20-alpine/silta/entrypoint.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env sh
+set -e
+
+## Run startup scripts
+for f in $(dirname "$0")/entrypoints/*.sh; do
+  if [ -r $f ]; then
+    . "$f"
+  fi
+done

--- a/silta-node/20-alpine/silta/entrypoints/00-umask.sh
+++ b/silta-node/20-alpine/silta/entrypoints/00-umask.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env sh
+
+umask 002

--- a/silta-node/lts-alpine/Dockerfile
+++ b/silta-node/lts-alpine/Dockerfile
@@ -9,6 +9,7 @@ RUN mkdir /etc/ssh/keys
 # Copy scripts
 COPY gitauth_keys.sh /etc/ssh/
 COPY entrypoint.sh /
+COPY silta /silta
 
 ENTRYPOINT ["/entrypoint.sh"]
 

--- a/silta-node/lts-alpine/TAGS
+++ b/silta-node/lts-alpine/TAGS
@@ -1,5 +1,5 @@
 lts-alpine-v0.1
-lts-alpine-v0.1.6
+lts-alpine-v0.1.7
 v0.1
-v0.1.6
+v0.1.7
 latest

--- a/silta-node/lts-alpine/entrypoint.sh
+++ b/silta-node/lts-alpine/entrypoint.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# Trigger silta entrypoint scripts if present.
+if [ -f /silta/entrypoint.sh ] ; then /silta/entrypoint.sh ; fi
+
 if [[ -v GITAUTH_URL ]]; then
 
     if [[ ! -f /etc/ssh/keys/ssh_host_rsa_key ]]; then
@@ -39,15 +42,16 @@ OUTSIDE_COLLABORATORS=${OUTSIDE_COLLABORATORS}
 EOF
 
     env > /etc/environment
-    addgroup www-admin
     # We add -D to make it non-interactive, but then the user is locked out.
-    adduser www-admin -D -G www-admin -s /bin/bash -h /app
+    adduser www-admin -D -G node -s /bin/bash -h /app
     # So set an empty password after the user is created.
     echo "www-admin:" | chpasswd
 
     # Pass environment variables down to container, so SSH can pick it up and drush commands work too.
     mkdir ~www-admin/.ssh/
     env | grep -v HOME > ~www-admin/.ssh/environment
+
+    echo "umask 0002" >> ~www-admin/.profile
 
     # run SSH server
     /usr/sbin/sshd -E /proc/self/fd/2

--- a/silta-node/lts-alpine/silta/.bashrc
+++ b/silta-node/lts-alpine/silta/.bashrc
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+source /silta/entrypoints/00-umask.sh
+
+if [ "${PS1-}" ]; then
+    PS1="\w$ "
+fi

--- a/silta-node/lts-alpine/silta/entrypoint.sh
+++ b/silta-node/lts-alpine/silta/entrypoint.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env sh
+set -e
+
+## Run startup scripts
+for f in $(dirname "$0")/entrypoints/*.sh; do
+  if [ -r $f ]; then
+    . "$f"
+  fi
+done

--- a/silta-node/lts-alpine/silta/entrypoints/00-umask.sh
+++ b/silta-node/lts-alpine/silta/entrypoints/00-umask.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env sh
+
+umask 002


### PR DESCRIPTION
Adds www-admin user to node group, sets umask to both ssh and node process. Implements entrypoint script support.