### PR TITLE
Upgrade gcloud to 445, for the old images

### DIFF
--- a/silta-cicd/circleci-php7.2-node14-composer1-v1/Dockerfile
+++ b/silta-cicd/circleci-php7.2-node14-composer1-v1/Dockerfile
@@ -19,7 +19,7 @@ RUN composer global require drush/drush-launcher:^0.8.0 hirak/prestissimo \
 RUN sudo apt-get update && sudo apt-get install vim && sudo apt-get clean
 
 # Add gcloud CLI and kubectl
-ENV GCLOUD_VERSION 392.0.0-0
+ENV GCLOUD_VERSION 445.0.0-0
 ENV USE_GKE_GCLOUD_AUTH_PLUGIN=True
 RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | sudo tee -a /etc/apt/sources.list.d/google-cloud-sdk.list \
   && sudo apt-get install apt-transport-https ca-certificates \

--- a/silta-cicd/circleci-php7.2-node14-composer1-v1/TAGS
+++ b/silta-cicd/circleci-php7.2-node14-composer1-v1/TAGS
@@ -1,3 +1,3 @@
 circleci-php7.2.34-node14.15.2-composer1
 circleci-php7.2-node14-composer1-v0.1
-circleci-php7.2-node14-composer1-v0.1.114
+circleci-php7.2-node14-composer1-v0.1.115

--- a/silta-cicd/circleci-php7.3-node12-composer1-v1/Dockerfile
+++ b/silta-cicd/circleci-php7.3-node12-composer1-v1/Dockerfile
@@ -14,7 +14,7 @@ RUN composer global require drush/drush-launcher:^0.8.0 hirak/prestissimo \
 RUN sudo apt-get update && sudo apt-get install vim && sudo apt-get clean
 
 # Add gcloud CLI and kubectl
-ENV GCLOUD_VERSION 392.0.0-0
+ENV GCLOUD_VERSION 445.0.0-0
 ENV USE_GKE_GCLOUD_AUTH_PLUGIN=True
 RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | sudo tee -a /etc/apt/sources.list.d/google-cloud-sdk.list \
   && sudo apt-get install apt-transport-https ca-certificates \

--- a/silta-cicd/circleci-php7.3-node12-composer1-v1/TAGS
+++ b/silta-cicd/circleci-php7.3-node12-composer1-v1/TAGS
@@ -1,6 +1,6 @@
 circleci-php7.3.19-node12.18.2-composer1
 circleci-php7.3-node12-composer1-v0.1
-circleci-php7.3-node12-composer1-v0.1.114
+circleci-php7.3-node12-composer1-v0.1.115
 v0.1
-v0.1.114
+v0.1.115
 latest

--- a/silta-cicd/circleci-php7.3-node14-composer1-v1/Dockerfile
+++ b/silta-cicd/circleci-php7.3-node14-composer1-v1/Dockerfile
@@ -19,7 +19,7 @@ RUN composer global require drush/drush-launcher:^0.8.0 hirak/prestissimo \
 RUN sudo apt-get update && sudo apt-get install vim && sudo apt-get clean
 
 # Add gcloud CLI and kubectl
-ENV GCLOUD_VERSION 392.0.0-0
+ENV GCLOUD_VERSION 445.0.0-0
 ENV USE_GKE_GCLOUD_AUTH_PLUGIN=True
 RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | sudo tee -a /etc/apt/sources.list.d/google-cloud-sdk.list \
   && sudo apt-get install apt-transport-https ca-certificates \

--- a/silta-cicd/circleci-php7.3-node14-composer1-v1/TAGS
+++ b/silta-cicd/circleci-php7.3-node14-composer1-v1/TAGS
@@ -1,3 +1,3 @@
 circleci-php7.3.23-node14.15.0-composer1
 circleci-php7.3-node14-composer1-v0.1
-circleci-php7.3-node14-composer1-v0.1.11
+circleci-php7.3-node14-composer1-v0.1.12

--- a/silta-cicd/circleci-php7.3-node14-composer2-v1/Dockerfile
+++ b/silta-cicd/circleci-php7.3-node14-composer2-v1/Dockerfile
@@ -14,7 +14,7 @@ RUN composer global require drush/drush-launcher:^0.8.0 \
 RUN sudo apt-get update && sudo apt-get install vim && sudo apt-get clean
 
 # Add gcloud CLI and kubectl
-ENV GCLOUD_VERSION 392.0.0-0
+ENV GCLOUD_VERSION 445.0.0-0
 ENV USE_GKE_GCLOUD_AUTH_PLUGIN=True
 RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | sudo tee -a /etc/apt/sources.list.d/google-cloud-sdk.list \
   && sudo apt-get install apt-transport-https ca-certificates \

--- a/silta-cicd/circleci-php7.3-node14-composer2-v1/TAGS
+++ b/silta-cicd/circleci-php7.3-node14-composer2-v1/TAGS
@@ -1,3 +1,3 @@
 circleci-php7.3.23-node14.15.0-composer2
 circleci-php7.3-node14-composer2-v0.1
-circleci-php7.3-node14-composer2-v0.1.11
+circleci-php7.3-node14-composer2-v0.1.12

--- a/silta-cicd/circleci-php7.4-node14-composer1-v1/Dockerfile
+++ b/silta-cicd/circleci-php7.4-node14-composer1-v1/Dockerfile
@@ -19,7 +19,7 @@ RUN sudo apt update && sudo apt upgrade && sudo apt clean
 RUN sudo apt-get update && sudo apt-get install vim && sudo apt-get clean
 
 # Add gcloud CLI and kubectl
-ENV GCLOUD_VERSION 392.0.0-0
+ENV GCLOUD_VERSION 445.0.0-0
 ENV USE_GKE_GCLOUD_AUTH_PLUGIN=True
 RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | sudo tee -a /etc/apt/sources.list.d/google-cloud-sdk.list \
   && sudo apt-get install apt-transport-https ca-certificates \

--- a/silta-cicd/circleci-php7.4-node14-composer1-v1/TAGS
+++ b/silta-cicd/circleci-php7.4-node14-composer1-v1/TAGS
@@ -1,3 +1,3 @@
 circleci-php7.4.12-node14.15.1-composer1
 circleci-php7.4-node14-composer1-v0.1
-circleci-php7.4-node14-composer1-v0.1.11
+circleci-php7.4-node14-composer1-v0.1.12

--- a/silta-cicd/circleci-php7.4-node14-composer2-v1/Dockerfile
+++ b/silta-cicd/circleci-php7.4-node14-composer2-v1/Dockerfile
@@ -14,7 +14,7 @@ RUN composer global require drush/drush-launcher:^0.8.0 \
 RUN sudo apt-get update && sudo apt-get install vim && sudo apt-get clean
 
 # Add gcloud CLI and kubectl
-ENV GCLOUD_VERSION 392.0.0-0
+ENV GCLOUD_VERSION 445.0.0-0
 ENV USE_GKE_GCLOUD_AUTH_PLUGIN=True
 RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | sudo tee -a /etc/apt/sources.list.d/google-cloud-sdk.list \
   && sudo apt-get install apt-transport-https ca-certificates \

--- a/silta-cicd/circleci-php7.4-node14-composer2-v1/TAGS
+++ b/silta-cicd/circleci-php7.4-node14-composer2-v1/TAGS
@@ -1,3 +1,3 @@
 circleci-php7.4.12-node14.15.1-composer2
 circleci-php7.4-node14-composer2-v0.1
-circleci-php7.4-node14-composer2-v0.1.12
+circleci-php7.4-node14-composer2-v0.1.13

--- a/silta-cicd/circleci-php7.4-node16-composer1-v1/Dockerfile
+++ b/silta-cicd/circleci-php7.4-node16-composer1-v1/Dockerfile
@@ -19,7 +19,7 @@ RUN sudo apt update && sudo apt upgrade && sudo apt clean
 RUN sudo apt-get update && sudo apt-get install vim && sudo apt-get clean
 
 # Add gcloud CLI and kubectl
-ENV GCLOUD_VERSION 392.0.0-0
+ENV GCLOUD_VERSION 445.0.0-0
 ENV USE_GKE_GCLOUD_AUTH_PLUGIN=True
 RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | sudo tee -a /etc/apt/sources.list.d/google-cloud-sdk.list \
   && sudo apt-get install apt-transport-https ca-certificates \

--- a/silta-cicd/circleci-php7.4-node16-composer1-v1/TAGS
+++ b/silta-cicd/circleci-php7.4-node16-composer1-v1/TAGS
@@ -1,3 +1,3 @@
 circleci-php7.4.27-node16.13.1-composer1
 circleci-php7.4-node16-composer1-v0.1
-circleci-php7.4-node16-composer1-v0.1.11
+circleci-php7.4-node16-composer1-v0.1.12

--- a/silta-cicd/circleci-php8.0-node14-composer2-v1/Dockerfile
+++ b/silta-cicd/circleci-php8.0-node14-composer2-v1/Dockerfile
@@ -14,7 +14,7 @@ RUN composer global require drush/drush-launcher:^0.8.0 \
 RUN sudo apt-get update && sudo apt-get install vim && sudo apt-get clean
 
 # Add gcloud CLI and kubectl
-ENV GCLOUD_VERSION 392.0.0-0
+ENV GCLOUD_VERSION 445.0.0-0
 ENV USE_GKE_GCLOUD_AUTH_PLUGIN=True
 RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | sudo tee -a /etc/apt/sources.list.d/google-cloud-sdk.list \
   && sudo apt-get install apt-transport-https ca-certificates \

--- a/silta-cicd/circleci-php8.0-node14-composer2-v1/TAGS
+++ b/silta-cicd/circleci-php8.0-node14-composer2-v1/TAGS
@@ -1,3 +1,3 @@
 circleci-php8.0.1-node14.15.4-composer2
 circleci-php8.0-node14-composer2-v0.1
-circleci-php8.0-node14-composer2-v0.1.10
+circleci-php8.0-node14-composer2-v0.1.11

--- a/silta-cicd/circleci-php8.0-node16-composer2-v1/Dockerfile
+++ b/silta-cicd/circleci-php8.0-node16-composer2-v1/Dockerfile
@@ -15,7 +15,7 @@ RUN sudo wget -q https://github.com/drush-ops/drush-launcher/releases/download/$
 RUN sudo apt-get update && sudo apt-get install vim && sudo apt-get clean
 
 # Add gcloud CLI and kubectl
-ENV GCLOUD_VERSION 392.0.0-0
+ENV GCLOUD_VERSION 445.0.0-0
 ENV USE_GKE_GCLOUD_AUTH_PLUGIN=True
 RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | sudo tee -a /etc/apt/sources.list.d/google-cloud-sdk.list \
   && sudo apt-get install apt-transport-https ca-certificates \

--- a/silta-cicd/circleci-php8.0-node16-composer2-v1/TAGS
+++ b/silta-cicd/circleci-php8.0-node16-composer2-v1/TAGS
@@ -1,3 +1,3 @@
 circleci-php8.0.13-node16.13.0-composer2
 circleci-php8.0-node16-composer2-v0.1
-circleci-php8.0-node16-composer2-v0.1.6
+circleci-php8.0-node16-composer2-v0.1.7

--- a/silta-cicd/circleci-php8.1-node16-composer2-v1/Dockerfile
+++ b/silta-cicd/circleci-php8.1-node16-composer2-v1/Dockerfile
@@ -15,7 +15,7 @@ RUN sudo wget -q https://github.com/drush-ops/drush-launcher/releases/download/$
 RUN sudo apt-get update && sudo apt-get install vim && sudo apt-get clean
 
 # Add gcloud CLI and kubectl
-ENV GCLOUD_VERSION 348.0.0-0
+ENV GCLOUD_VERSION 445.0.0-0
 RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | sudo tee -a /etc/apt/sources.list.d/google-cloud-sdk.list \
   && sudo apt-get install apt-transport-https ca-certificates \
   && curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key --keyring /usr/share/keyrings/cloud.google.gpg add - \

--- a/silta-cicd/circleci-php8.1-node16-composer2-v1/TAGS
+++ b/silta-cicd/circleci-php8.1-node16-composer2-v1/TAGS
@@ -1,3 +1,3 @@
 circleci-php8.1.7-node16.15.1-composer2
 circleci-php8.1-node16-composer2-v0.1
-circleci-php8.1-node16-composer2-v0.1.2
+circleci-php8.1-node16-composer2-v0.1.3


### PR DESCRIPTION
Updates older v1 images to use newest gcloud cli, to support 1.26 GKE clusters

For reference, any breaking changes in gloud can be found in the Release notes: https://cloud.google.com/sdk/docs/release-notes#39900_2022-08-23

This PR upgrades gcloud from version 399 to 445.