### PR TITLE
Upgrade Helm from 3.6.3 to 3.13.3

### DIFF
--- a/silta-cicd/circleci-php7.2-node14-composer1/Dockerfile
+++ b/silta-cicd/circleci-php7.2-node14-composer1/Dockerfile
@@ -34,7 +34,7 @@ RUN sudo apt install -y awscli git python3 \
   && sudo mv /tmp/aws-iam-authenticator /bin/aws-iam-authenticator
 
 # Install Helm 3
-ENV HELM_VERSION v3.6.3
+ENV HELM_VERSION v3.13.3
 ENV FILENAME helm-${HELM_VERSION}-linux-amd64.tar.gz
 ENV HELM_URL https://get.helm.sh/${FILENAME}
 

--- a/silta-cicd/circleci-php7.2-node14-composer1/README.md
+++ b/silta-cicd/circleci-php7.2-node14-composer1/README.md
@@ -10,4 +10,4 @@ A docker image used circleCI, based on `circleci/php:7.2-cli-node` with the foll
 - PHP: 7.2.34
 - Composer: 1.x
 - Node: 14.15.2
-- Helm: v3.6.3
+- Helm: v3.13.3

--- a/silta-cicd/circleci-php7.2-node14-composer1/TAGS
+++ b/silta-cicd/circleci-php7.2-node14-composer1/TAGS
@@ -1,3 +1,3 @@
 circleci-php7.2-node14-composer1-v1
-circleci-php7.2-node14-composer1-v1.1
-circleci-php7.2-node14-composer1-v1.1.0
+circleci-php7.2-node14-composer1-v1.2
+circleci-php7.2-node14-composer1-v1.2.0

--- a/silta-cicd/circleci-php7.3-node12-composer1/Dockerfile
+++ b/silta-cicd/circleci-php7.3-node12-composer1/Dockerfile
@@ -29,7 +29,7 @@ RUN sudo apt install -y awscli git python3 \
   && sudo mv /tmp/aws-iam-authenticator /bin/aws-iam-authenticator
 
 # Install Helm 3
-ENV HELM_VERSION v3.6.3
+ENV HELM_VERSION v3.13.3
 ENV FILENAME helm-${HELM_VERSION}-linux-amd64.tar.gz
 ENV HELM_URL https://get.helm.sh/${FILENAME}
 

--- a/silta-cicd/circleci-php7.3-node12-composer1/README.md
+++ b/silta-cicd/circleci-php7.3-node12-composer1/README.md
@@ -10,4 +10,4 @@ A docker image used circleCI, based on `circleci/php:7.3-cli-node` with the foll
 - PHP: 7.3.19
 - Composer: 1.x
 - Node: 12.18.2
-- Helm: v3.6.3
+- Helm: v3.13.3

--- a/silta-cicd/circleci-php7.3-node12-composer1/TAGS
+++ b/silta-cicd/circleci-php7.3-node12-composer1/TAGS
@@ -1,3 +1,3 @@
 circleci-php7.3-node12-composer1-v1
-circleci-php7.3-node12-composer1-v1.1
-circleci-php7.3-node12-composer1-v1.1.0
+circleci-php7.3-node12-composer1-v1.2
+circleci-php7.3-node12-composer1-v1.2.0

--- a/silta-cicd/circleci-php7.3-node14-composer1/Dockerfile
+++ b/silta-cicd/circleci-php7.3-node14-composer1/Dockerfile
@@ -34,7 +34,7 @@ RUN sudo apt install -y awscli git python3 \
   && sudo mv /tmp/aws-iam-authenticator /bin/aws-iam-authenticator
 
 # Install Helm 3
-ENV HELM_VERSION v3.6.3
+ENV HELM_VERSION v3.13.3
 ENV FILENAME helm-${HELM_VERSION}-linux-amd64.tar.gz
 ENV HELM_URL https://get.helm.sh/${FILENAME}
 

--- a/silta-cicd/circleci-php7.3-node14-composer1/README.md
+++ b/silta-cicd/circleci-php7.3-node14-composer1/README.md
@@ -10,4 +10,4 @@ A docker image used circleCI, based on `circleci/php:7.3-cli-node` with the foll
 - PHP: 7.3.23
 - Composer: 1.x
 - Node: 14.15.0
-- Helm: v3.6.3
+- Helm: v3.13.3

--- a/silta-cicd/circleci-php7.3-node14-composer1/TAGS
+++ b/silta-cicd/circleci-php7.3-node14-composer1/TAGS
@@ -1,3 +1,3 @@
 circleci-php7.3-node14-composer1-v1
-circleci-php7.3-node14-composer1-v1.1
-circleci-php7.3-node14-composer1-v1.1.0
+circleci-php7.3-node14-composer1-v1.2
+circleci-php7.3-node14-composer1-v1.2.0

--- a/silta-cicd/circleci-php7.3-node14-composer2/Dockerfile
+++ b/silta-cicd/circleci-php7.3-node14-composer2/Dockerfile
@@ -29,7 +29,7 @@ RUN sudo apt install -y awscli git python3 \
   && sudo mv /tmp/aws-iam-authenticator /bin/aws-iam-authenticator
 
 # Install Helm 3
-ENV HELM_VERSION v3.6.3
+ENV HELM_VERSION v3.13.3
 ENV FILENAME helm-${HELM_VERSION}-linux-amd64.tar.gz
 ENV HELM_URL https://get.helm.sh/${FILENAME}
 

--- a/silta-cicd/circleci-php7.3-node14-composer2/README.md
+++ b/silta-cicd/circleci-php7.3-node14-composer2/README.md
@@ -10,4 +10,4 @@ A docker image used circleCI, based on `circleci/php:7.3-cli-node` with the foll
 - PHP: 7.3.23
 - Composer: 2.x
 - Node: 14.15.0
-- Helm: v3.6.3
+- Helm: v3.13.3

--- a/silta-cicd/circleci-php7.3-node14-composer2/TAGS
+++ b/silta-cicd/circleci-php7.3-node14-composer2/TAGS
@@ -1,3 +1,3 @@
 circleci-php7.3-node14-composer2-v1
-circleci-php7.3-node14-composer2-v1.1
-circleci-php7.3-node14-composer2-v1.1.0
+circleci-php7.3-node14-composer2-v1.2
+circleci-php7.3-node14-composer2-v1.2.0

--- a/silta-cicd/circleci-php7.4-node14-composer1/Dockerfile
+++ b/silta-cicd/circleci-php7.4-node14-composer1/Dockerfile
@@ -34,7 +34,7 @@ RUN sudo apt install -y awscli git python3 \
   && sudo mv /tmp/aws-iam-authenticator /bin/aws-iam-authenticator
 
 # Install Helm 3
-ENV HELM_VERSION v3.6.3
+ENV HELM_VERSION v3.13.3
 ENV FILENAME helm-${HELM_VERSION}-linux-amd64.tar.gz
 ENV HELM_URL https://get.helm.sh/${FILENAME}
 

--- a/silta-cicd/circleci-php7.4-node14-composer1/README.md
+++ b/silta-cicd/circleci-php7.4-node14-composer1/README.md
@@ -10,4 +10,4 @@ A docker image used circleCI, based on `circleci/php:7.4-cli-node` with the foll
 - PHP: 7.4.12
 - Composer: 1.x
 - Node: 14.15.1
-- Helm: v3.6.3
+- Helm: v3.13.3

--- a/silta-cicd/circleci-php7.4-node14-composer1/TAGS
+++ b/silta-cicd/circleci-php7.4-node14-composer1/TAGS
@@ -1,3 +1,3 @@
 circleci-php7.4-node14-composer1-v1
-circleci-php7.4-node14-composer1-v1.1
-circleci-php7.4-node14-composer1-v1.1.0
+circleci-php7.4-node14-composer1-v1.2
+circleci-php7.4-node14-composer1-v1.2.0

--- a/silta-cicd/circleci-php7.4-node14-composer2/Dockerfile
+++ b/silta-cicd/circleci-php7.4-node14-composer2/Dockerfile
@@ -29,7 +29,7 @@ RUN sudo apt install -y awscli git python3 \
   && sudo mv /tmp/aws-iam-authenticator /bin/aws-iam-authenticator
 
 # Install Helm 3
-ENV HELM_VERSION v3.6.3
+ENV HELM_VERSION v3.13.3
 ENV FILENAME helm-${HELM_VERSION}-linux-amd64.tar.gz
 ENV HELM_URL https://get.helm.sh/${FILENAME}
 

--- a/silta-cicd/circleci-php7.4-node14-composer2/README.md
+++ b/silta-cicd/circleci-php7.4-node14-composer2/README.md
@@ -10,4 +10,4 @@ A docker image used circleCI, based on `circleci/php:7.4-cli-node` with the foll
 - PHP: 7.4.12
 - Composer: 2.x
 - Node: 14.15.1
-- Helm: v3.6.3
+- Helm: v3.13.3

--- a/silta-cicd/circleci-php7.4-node14-composer2/TAGS
+++ b/silta-cicd/circleci-php7.4-node14-composer2/TAGS
@@ -1,3 +1,3 @@
 circleci-php7.4-node14-composer2-v1
-circleci-php7.4-node14-composer2-v1.1
-circleci-php7.4-node14-composer2-v1.1.0
+circleci-php7.4-node14-composer2-v1.2
+circleci-php7.4-node14-composer2-v1.2.0

--- a/silta-cicd/circleci-php7.4-node16-composer1/Dockerfile
+++ b/silta-cicd/circleci-php7.4-node16-composer1/Dockerfile
@@ -34,7 +34,7 @@ RUN sudo apt install -y awscli git python3 \
   && sudo mv /tmp/aws-iam-authenticator /bin/aws-iam-authenticator
 
 # Install Helm 3
-ENV HELM_VERSION v3.6.3
+ENV HELM_VERSION v3.13.3
 ENV FILENAME helm-${HELM_VERSION}-linux-amd64.tar.gz
 ENV HELM_URL https://get.helm.sh/${FILENAME}
 

--- a/silta-cicd/circleci-php7.4-node16-composer1/README.md
+++ b/silta-cicd/circleci-php7.4-node16-composer1/README.md
@@ -10,4 +10,4 @@ A docker image used circleCI, based on `circleci/php:7.4-cli-node` with the foll
 - PHP: 7.4.27
 - Composer: 1.x
 - Node: 16.13.1
-- Helm: v3.6.3
+- Helm: v3.13.3

--- a/silta-cicd/circleci-php7.4-node16-composer1/TAGS
+++ b/silta-cicd/circleci-php7.4-node16-composer1/TAGS
@@ -1,3 +1,3 @@
 circleci-php7.4-node16-composer1-v1
-circleci-php7.4-node16-composer1-v1.1
-circleci-php7.4-node16-composer1-v1.1.0
+circleci-php7.4-node16-composer1-v1.2
+circleci-php7.4-node16-composer1-v1.2.0

--- a/silta-cicd/circleci-php8.0-node14-composer2/Dockerfile
+++ b/silta-cicd/circleci-php8.0-node14-composer2/Dockerfile
@@ -28,7 +28,7 @@ RUN sudo apt install -y awscli git python3 \
   && sudo mv /tmp/aws-iam-authenticator /bin/aws-iam-authenticator
 
 # Install Helm 3
-ENV HELM_VERSION v3.6.3
+ENV HELM_VERSION v3.13.3
 ENV FILENAME helm-${HELM_VERSION}-linux-amd64.tar.gz
 ENV HELM_URL https://get.helm.sh/${FILENAME}
 

--- a/silta-cicd/circleci-php8.0-node14-composer2/README.md
+++ b/silta-cicd/circleci-php8.0-node14-composer2/README.md
@@ -10,4 +10,4 @@ A docker image used circleCI, based on `circleci/php:7.4-cli-node` with the foll
 - PHP: 8.0.1
 - Composer: 2.x
 - Node: 14.15.4
-- Helm: v3.6.3
+- Helm: v3.13.3

--- a/silta-cicd/circleci-php8.0-node14-composer2/TAGS
+++ b/silta-cicd/circleci-php8.0-node14-composer2/TAGS
@@ -1,3 +1,3 @@
 circleci-php8.0-node14-composer2-v1
-circleci-php8.0-node14-composer2-v1.1
-circleci-php8.0-node14-composer2-v1.1.0
+circleci-php8.0-node14-composer2-v1.2
+circleci-php8.0-node14-composer2-v1.2.0

--- a/silta-cicd/circleci-php8.0-node16-composer2/Dockerfile
+++ b/silta-cicd/circleci-php8.0-node16-composer2/Dockerfile
@@ -30,7 +30,7 @@ RUN sudo apt install -y awscli git python3 \
   && sudo mv /tmp/aws-iam-authenticator /bin/aws-iam-authenticator
 
 # Install Helm 3
-ENV HELM_VERSION v3.6.3
+ENV HELM_VERSION v3.13.3
 ENV FILENAME helm-${HELM_VERSION}-linux-amd64.tar.gz
 ENV HELM_URL https://get.helm.sh/${FILENAME}
 

--- a/silta-cicd/circleci-php8.0-node16-composer2/README.md
+++ b/silta-cicd/circleci-php8.0-node16-composer2/README.md
@@ -10,4 +10,4 @@ A docker image used circleCI, based on `cimg/php:8.0.13-node` with the following
 - PHP: 8.0.13
 - Composer: 2.1.12
 - Node: 16.13.0
-- Helm: v3.6.3
+- Helm: v3.13.3

--- a/silta-cicd/circleci-php8.0-node16-composer2/TAGS
+++ b/silta-cicd/circleci-php8.0-node16-composer2/TAGS
@@ -1,3 +1,3 @@
 circleci-php8.0-node16-composer2-v1
-circleci-php8.0-node16-composer2-v1.1
-circleci-php8.0-node16-composer2-v1.1.0
+circleci-php8.0-node16-composer2-v1.2
+circleci-php8.0-node16-composer2-v1.2.0

--- a/silta-cicd/circleci-php8.1-node16-composer2/Dockerfile
+++ b/silta-cicd/circleci-php8.1-node16-composer2/Dockerfile
@@ -29,7 +29,7 @@ RUN sudo apt install -y awscli git python3 \
   && sudo mv /tmp/aws-iam-authenticator /bin/aws-iam-authenticator
 
 # Install Helm 3
-ENV HELM_VERSION v3.6.3
+ENV HELM_VERSION v3.13.3
 ENV FILENAME helm-${HELM_VERSION}-linux-amd64.tar.gz
 ENV HELM_URL https://get.helm.sh/${FILENAME}
 

--- a/silta-cicd/circleci-php8.1-node16-composer2/README.md
+++ b/silta-cicd/circleci-php8.1-node16-composer2/README.md
@@ -10,4 +10,4 @@ A docker image used circleCI, based on `cimg/php:8.1.7-node` with the following 
 - PHP: 8.1.7
 - Composer: 2.1.12
 - Node: 16.15.1
-- Helm: v3.6.3
+- Helm: v3.13.3

--- a/silta-cicd/circleci-php8.1-node16-composer2/TAGS
+++ b/silta-cicd/circleci-php8.1-node16-composer2/TAGS
@@ -1,3 +1,3 @@
 circleci-php8.1-node16-composer2-v1
-circleci-php8.1-node16-composer2-v1.1
-circleci-php8.1-node16-composer2-v1.1.0
+circleci-php8.1-node16-composer2-v1.2
+circleci-php8.1-node16-composer2-v1.2.0

--- a/silta-cicd/circleci-php8.1-node18-composer2/Dockerfile
+++ b/silta-cicd/circleci-php8.1-node18-composer2/Dockerfile
@@ -28,7 +28,7 @@ RUN sudo apt install -y awscli git python3 \
   && sudo mv /tmp/aws-iam-authenticator /bin/aws-iam-authenticator
 
 # Install Helm 3
-ENV HELM_VERSION v3.6.3
+ENV HELM_VERSION v3.13.3
 ENV FILENAME helm-${HELM_VERSION}-linux-amd64.tar.gz
 ENV HELM_URL https://get.helm.sh/${FILENAME}
 

--- a/silta-cicd/circleci-php8.1-node18-composer2/README.md
+++ b/silta-cicd/circleci-php8.1-node18-composer2/README.md
@@ -10,4 +10,4 @@ A docker image used circleCI, based on `cimg/php:8.1.23-node` with the following
 - PHP: 8.1.23
 - Composer: 2.5.1
 - Node: 18.17.1
-- Helm: v3.6.3
+- Helm: v3.13.3

--- a/silta-cicd/circleci-php8.1-node18-composer2/TAGS
+++ b/silta-cicd/circleci-php8.1-node18-composer2/TAGS
@@ -1,3 +1,3 @@
 circleci-php8.1-node18-composer2-v1
-circleci-php8.1-node18-composer2-v1.1
-circleci-php8.1-node18-composer2-v1.1.0
+circleci-php8.1-node18-composer2-v1.2
+circleci-php8.1-node18-composer2-v1.2.0

--- a/silta-cicd/circleci-php8.2-node18-composer2/Dockerfile
+++ b/silta-cicd/circleci-php8.2-node18-composer2/Dockerfile
@@ -28,7 +28,7 @@ RUN sudo apt install -y awscli git python3 \
   && sudo mv /tmp/aws-iam-authenticator /bin/aws-iam-authenticator
 
 # Install Helm 3
-ENV HELM_VERSION v3.6.3
+ENV HELM_VERSION v3.13.3
 ENV FILENAME helm-${HELM_VERSION}-linux-amd64.tar.gz
 ENV HELM_URL https://get.helm.sh/${FILENAME}
 

--- a/silta-cicd/circleci-php8.2-node18-composer2/README.md
+++ b/silta-cicd/circleci-php8.2-node18-composer2/README.md
@@ -10,4 +10,4 @@ A docker image used circleCI, based on `cimg/php:8.1.7-node` with the following 
 - PHP: 8.2.0
 - Composer: 2.1.12
 - Node: 18.12.1
-- Helm: v3.6.3
+- Helm: v3.13.3

--- a/silta-cicd/circleci-php8.2-node18-composer2/TAGS
+++ b/silta-cicd/circleci-php8.2-node18-composer2/TAGS
@@ -1,3 +1,3 @@
 circleci-php8.2-node18-composer2-v1
-circleci-php8.2-node18-composer2-v1.1
-circleci-php8.2-node18-composer2-v1.1.0
+circleci-php8.2-node18-composer2-v1.2
+circleci-php8.2-node18-composer2-v1.2.0

--- a/silta-cicd/circleci-php8.2-node20-composer2/Dockerfile
+++ b/silta-cicd/circleci-php8.2-node20-composer2/Dockerfile
@@ -28,7 +28,7 @@ RUN sudo apt install -y awscli git python3 \
   && sudo mv /tmp/aws-iam-authenticator /bin/aws-iam-authenticator
 
 # Install Helm 3
-ENV HELM_VERSION v3.6.3
+ENV HELM_VERSION v3.13.3
 ENV FILENAME helm-${HELM_VERSION}-linux-amd64.tar.gz
 ENV HELM_URL https://get.helm.sh/${FILENAME}
 

--- a/silta-cicd/circleci-php8.2-node20-composer2/README.md
+++ b/silta-cicd/circleci-php8.2-node20-composer2/README.md
@@ -10,4 +10,4 @@ A docker image used circleCI, based on `cimg/php:8.2.13-node` with the following
 - PHP: 8.2.13
 - Composer: 2.5.1
 - Node: 20.9.0
-- Helm: v3.6.3
+- Helm: v3.13.3

--- a/silta-cicd/circleci-php8.2-node20-composer2/TAGS
+++ b/silta-cicd/circleci-php8.2-node20-composer2/TAGS
@@ -1,3 +1,3 @@
 circleci-php8.2-node20-composer2-v1
-circleci-php8.2-node20-composer2-v1.0
-circleci-php8.2-node20-composer2-v1.0.0
+circleci-php8.2-node20-composer2-v1.1
+circleci-php8.2-node20-composer2-v1.1.0


### PR DESCRIPTION
fixes subchart usage issue.

This PR is blocked by: https://github.com/wunderio/drupal-project-k8s/pull/679

# Merge only when drupal chart fix is fully released in charts repository.