### PR TITLE
Bump node 18 (18.17->18.19) and node 20 (20.5->20.11) images

### DIFF
--- a/silta-node/18-alpine/Dockerfile
+++ b/silta-node/18-alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18.17-alpine
+FROM node:18.19-alpine
 
 RUN apk add --no-cache openssh bash rsync curl tzdata
 

--- a/silta-node/18-alpine/TAGS
+++ b/silta-node/18-alpine/TAGS
@@ -1,3 +1,3 @@
 18-alpine-v1
 18-alpine-v1.1
-18-alpine-v1.1.0
+18-alpine-v1.1.1

--- a/silta-node/20-alpine/Dockerfile
+++ b/silta-node/20-alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20.5-alpine
+FROM node:20.11-alpine
 
 RUN apk add --no-cache openssh bash rsync curl tzdata
 

--- a/silta-node/20-alpine/TAGS
+++ b/silta-node/20-alpine/TAGS
@@ -1,3 +1,3 @@
 20-alpine-v1
 20-alpine-v1.1
-20-alpine-v1.1.0
+20-alpine-v1.1.1


### PR DESCRIPTION
Added this to resolve this issue that was introduced to node 18 at some point:
https://github.com/nodejs/node/issues/47259

See also:
https://wunder.slack.com/archives/C468AG2CS/p1707901313913999