### PR TITLE
For cicd images using cimg/php as base image: Install node.js and yarn ourselves

### DIFF
--- a/silta-cicd/circleci-php8.0-node16-composer2/Dockerfile
+++ b/silta-cicd/circleci-php8.0-node16-composer2/Dockerfile
@@ -71,7 +71,7 @@ RUN curl -L -o yarn.tar.gz "https://yarnpkg.com/downloads/${YARN_VERSION}/yarn-v
 	sudo tar -xzf yarn.tar.gz -C /opt/ && \
 	rm yarn.tar.gz && \
 	sudo ln -s /opt/yarn-v${YARN_VERSION}/bin/yarn /usr/local/bin/yarn && \
-	sudo ln -s /opt/yarn-v${YARN_VERSION}/bin/yarnpkg /usr/local/bin/yarnpkg \
+	sudo ln -s /opt/yarn-v${YARN_VERSION}/bin/yarnpkg /usr/local/bin/yarnpkg
 
 # Add custom php config and lift memory limit.
 COPY conf/php/memory.ini /usr/local/etc/php/conf.d/memory.ini

--- a/silta-cicd/circleci-php8.0-node16-composer2/Dockerfile
+++ b/silta-cicd/circleci-php8.0-node16-composer2/Dockerfile
@@ -1,4 +1,4 @@
-FROM cimg/php:8.0.13-node
+FROM cimg/php:8.0.13
 
 # Make composer packages executable.
 ENV PATH="/home/circleci/.composer/vendor/bin:${PATH}"
@@ -55,6 +55,23 @@ RUN sudo apt-get clean autoclean -y \
 
 # TODO: when https://github.com/lrills/helm-unittest/issues/87 is merged,
 # switch back to using https://github.com/lrills/helm-unittest as the source
+
+# Install Node.js and Yarn.
+# The following code is based on the CircleCI Node.js Dockerfile template:
+# https://github.com/CircleCI-Public/cimg-shared/blob/main/variants/node.Dockerfile.template
+ENV NODE_VERSION 16.13.0
+RUN echo "Installing Node.js version ${NODE_VERSION}"
+RUN curl -L -o node.tar.xz "https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-x64.tar.xz" && \
+	sudo tar -xJf node.tar.xz -C /usr/local --strip-components=1 && \
+	rm node.tar.xz && \
+	sudo ln -s /usr/local/bin/node /usr/local/bin/nodejs
+
+ENV YARN_VERSION 1.22.5
+RUN curl -L -o yarn.tar.gz "https://yarnpkg.com/downloads/${YARN_VERSION}/yarn-v${YARN_VERSION}.tar.gz" && \
+	sudo tar -xzf yarn.tar.gz -C /opt/ && \
+	rm yarn.tar.gz && \
+	sudo ln -s /opt/yarn-v${YARN_VERSION}/bin/yarn /usr/local/bin/yarn && \
+	sudo ln -s /opt/yarn-v${YARN_VERSION}/bin/yarnpkg /usr/local/bin/yarnpkg \
 
 # Add custom php config and lift memory limit.
 COPY conf/php/memory.ini /usr/local/etc/php/conf.d/memory.ini

--- a/silta-cicd/circleci-php8.0-node16-composer2/README.md
+++ b/silta-cicd/circleci-php8.0-node16-composer2/README.md
@@ -1,13 +1,16 @@
 # silta-circleci
-A docker image used circleCI, based on `cimg/php:8.0.13-node` with the following additions:
+A docker image used circleCI, based on `cimg/php:8.0.13` with the following additions:
 
 - Composer configured correctly
 - Drush-launcher and coder pre-installed
 - Vim, useful for debugging
 - kubernetes and helm
+- Node.js
+- Yarn
 
 ## Versions
 - PHP: 8.0.13
 - Composer: 2.1.12
 - Node: 16.13.0
+- Yarn: 1.22.5
 - Helm: v3.14.0

--- a/silta-cicd/circleci-php8.0-node16-composer2/TAGS
+++ b/silta-cicd/circleci-php8.0-node16-composer2/TAGS
@@ -1,3 +1,3 @@
 circleci-php8.0-node16-composer2-v1
-circleci-php8.0-node16-composer2-v1.4
-circleci-php8.0-node16-composer2-v1.4.0
+circleci-php8.0-node16-composer2-v1.5
+circleci-php8.0-node16-composer2-v1.5.0

--- a/silta-cicd/circleci-php8.1-node16-composer2/Dockerfile
+++ b/silta-cicd/circleci-php8.1-node16-composer2/Dockerfile
@@ -67,7 +67,7 @@ RUN curl -L -o yarn.tar.gz "https://yarnpkg.com/downloads/${YARN_VERSION}/yarn-v
 	sudo tar -xzf yarn.tar.gz -C /opt/ && \
 	rm yarn.tar.gz && \
 	sudo ln -s /opt/yarn-v${YARN_VERSION}/bin/yarn /usr/local/bin/yarn && \
-	sudo ln -s /opt/yarn-v${YARN_VERSION}/bin/yarnpkg /usr/local/bin/yarnpkg \
+	sudo ln -s /opt/yarn-v${YARN_VERSION}/bin/yarnpkg /usr/local/bin/yarnpkg
 
 # Add custom php config and lift memory limit.
 COPY conf/php/memory.ini /usr/local/etc/php/conf.d/memory.ini

--- a/silta-cicd/circleci-php8.1-node16-composer2/Dockerfile
+++ b/silta-cicd/circleci-php8.1-node16-composer2/Dockerfile
@@ -1,4 +1,4 @@
-FROM cimg/php:8.1.7-node
+FROM cimg/php:8.1.7
 
 # Make composer packages executable.
 ENV PATH="/home/circleci/.composer/vendor/bin:${PATH}"
@@ -51,6 +51,23 @@ RUN curl -o /tmp/$FILENAME ${HELM_URL} \
 
 # TODO: when https://github.com/lrills/helm-unittest/issues/87 is merged,
 # switch back to using https://github.com/lrills/helm-unittest as the source
+
+# Install Node.js and Yarn.
+# The following code is based on the CircleCI Node.js Dockerfile template:
+# https://github.com/CircleCI-Public/cimg-shared/blob/main/variants/node.Dockerfile.template
+ENV NODE_VERSION 16.15.1
+RUN echo "Installing Node.js version ${NODE_VERSION}"
+RUN curl -L -o node.tar.xz "https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-x64.tar.xz" && \
+	sudo tar -xJf node.tar.xz -C /usr/local --strip-components=1 && \
+	rm node.tar.xz && \
+	sudo ln -s /usr/local/bin/node /usr/local/bin/nodejs
+
+ENV YARN_VERSION 1.22.5
+RUN curl -L -o yarn.tar.gz "https://yarnpkg.com/downloads/${YARN_VERSION}/yarn-v${YARN_VERSION}.tar.gz" && \
+	sudo tar -xzf yarn.tar.gz -C /opt/ && \
+	rm yarn.tar.gz && \
+	sudo ln -s /opt/yarn-v${YARN_VERSION}/bin/yarn /usr/local/bin/yarn && \
+	sudo ln -s /opt/yarn-v${YARN_VERSION}/bin/yarnpkg /usr/local/bin/yarnpkg \
 
 # Add custom php config and lift memory limit.
 COPY conf/php/memory.ini /usr/local/etc/php/conf.d/memory.ini

--- a/silta-cicd/circleci-php8.1-node16-composer2/README.md
+++ b/silta-cicd/circleci-php8.1-node16-composer2/README.md
@@ -1,13 +1,16 @@
 # silta-circleci
-A docker image used circleCI, based on `cimg/php:8.1.7-node` with the following additions:
+A docker image used circleCI, based on `cimg/php:8.1.7` with the following additions:
 
 - Composer configured correctly
 - Drush-launcher and coder pre-installed
 - Vim, useful for debugging
 - kubernetes and helm
+- Node.js
+- Yarn
 
 ## Versions
 - PHP: 8.1.7
 - Composer: 2.1.12
 - Node: 16.15.1
+- Yarn: 1.22.5
 - Helm: v3.14.0

--- a/silta-cicd/circleci-php8.1-node16-composer2/TAGS
+++ b/silta-cicd/circleci-php8.1-node16-composer2/TAGS
@@ -1,3 +1,3 @@
 circleci-php8.1-node16-composer2-v1
-circleci-php8.1-node16-composer2-v1.3
-circleci-php8.1-node16-composer2-v1.3.0
+circleci-php8.1-node16-composer2-v1.4
+circleci-php8.1-node16-composer2-v1.4.0

--- a/silta-cicd/circleci-php8.1-node18-composer2/Dockerfile
+++ b/silta-cicd/circleci-php8.1-node18-composer2/Dockerfile
@@ -1,4 +1,4 @@
-FROM cimg/php:8.1.23-node
+FROM cimg/php:8.1.23
 
 # Make composer packages executable.
 ENV PATH="/home/circleci/.composer/vendor/bin:${PATH}"
@@ -50,6 +50,23 @@ RUN curl -o /tmp/$FILENAME ${HELM_URL} \
 
 # TODO: when https://github.com/lrills/helm-unittest/issues/87 is merged,
 # switch back to using https://github.com/lrills/helm-unittest as the source
+
+# Install Node.js and Yarn.
+# The following code is based on the CircleCI Node.js Dockerfile template:
+# https://github.com/CircleCI-Public/cimg-shared/blob/main/variants/node.Dockerfile.template
+ENV NODE_VERSION 18.17.1
+RUN echo "Installing Node.js version ${NODE_VERSION}"
+RUN curl -L -o node.tar.xz "https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-x64.tar.xz" && \
+	sudo tar -xJf node.tar.xz -C /usr/local --strip-components=1 && \
+	rm node.tar.xz && \
+	sudo ln -s /usr/local/bin/node /usr/local/bin/nodejs
+
+ENV YARN_VERSION 1.22.19
+RUN curl -L -o yarn.tar.gz "https://yarnpkg.com/downloads/${YARN_VERSION}/yarn-v${YARN_VERSION}.tar.gz" && \
+	sudo tar -xzf yarn.tar.gz -C /opt/ && \
+	rm yarn.tar.gz && \
+	sudo ln -s /opt/yarn-v${YARN_VERSION}/bin/yarn /usr/local/bin/yarn && \
+	sudo ln -s /opt/yarn-v${YARN_VERSION}/bin/yarnpkg /usr/local/bin/yarnpkg \
 
 # Add custom php config and lift memory limit.
 COPY conf/php/memory.ini /usr/local/etc/php/conf.d/memory.ini

--- a/silta-cicd/circleci-php8.1-node18-composer2/Dockerfile
+++ b/silta-cicd/circleci-php8.1-node18-composer2/Dockerfile
@@ -66,7 +66,7 @@ RUN curl -L -o yarn.tar.gz "https://yarnpkg.com/downloads/${YARN_VERSION}/yarn-v
 	sudo tar -xzf yarn.tar.gz -C /opt/ && \
 	rm yarn.tar.gz && \
 	sudo ln -s /opt/yarn-v${YARN_VERSION}/bin/yarn /usr/local/bin/yarn && \
-	sudo ln -s /opt/yarn-v${YARN_VERSION}/bin/yarnpkg /usr/local/bin/yarnpkg \
+	sudo ln -s /opt/yarn-v${YARN_VERSION}/bin/yarnpkg /usr/local/bin/yarnpkg
 
 # Add custom php config and lift memory limit.
 COPY conf/php/memory.ini /usr/local/etc/php/conf.d/memory.ini

--- a/silta-cicd/circleci-php8.1-node18-composer2/README.md
+++ b/silta-cicd/circleci-php8.1-node18-composer2/README.md
@@ -1,13 +1,16 @@
 # silta-circleci
-A docker image used circleCI, based on `cimg/php:8.1.23-node` with the following additions:
+A docker image used circleCI, based on `cimg/php:8.1.23` with the following additions:
 
 - Composer configured correctly
 - Drush-launcher and coder pre-installed
 - Vim, useful for debugging
 - kubernetes and helm
+- Node.js
+- Yarn
 
 ## Versions
 - PHP: 8.1.23
 - Composer: 2.5.1
 - Node: 18.17.1
+- Yarn: 1.22.19
 - Helm: v3.14.0

--- a/silta-cicd/circleci-php8.1-node18-composer2/TAGS
+++ b/silta-cicd/circleci-php8.1-node18-composer2/TAGS
@@ -1,3 +1,3 @@
 circleci-php8.1-node18-composer2-v1
-circleci-php8.1-node18-composer2-v1.3
-circleci-php8.1-node18-composer2-v1.3.0
+circleci-php8.1-node18-composer2-v1.4
+circleci-php8.1-node18-composer2-v1.4.0

--- a/silta-cicd/circleci-php8.2-node18-composer2/Dockerfile
+++ b/silta-cicd/circleci-php8.2-node18-composer2/Dockerfile
@@ -66,7 +66,7 @@ RUN curl -L -o yarn.tar.gz "https://yarnpkg.com/downloads/${YARN_VERSION}/yarn-v
 	sudo tar -xzf yarn.tar.gz -C /opt/ && \
 	rm yarn.tar.gz && \
 	sudo ln -s /opt/yarn-v${YARN_VERSION}/bin/yarn /usr/local/bin/yarn && \
-	sudo ln -s /opt/yarn-v${YARN_VERSION}/bin/yarnpkg /usr/local/bin/yarnpkg \
+	sudo ln -s /opt/yarn-v${YARN_VERSION}/bin/yarnpkg /usr/local/bin/yarnpkg
 
 # Add custom php config and lift memory limit.
 COPY conf/php/memory.ini /usr/local/etc/php/conf.d/memory.ini

--- a/silta-cicd/circleci-php8.2-node18-composer2/Dockerfile
+++ b/silta-cicd/circleci-php8.2-node18-composer2/Dockerfile
@@ -1,4 +1,4 @@
-FROM cimg/php:8.2.12-node
+FROM cimg/php:8.2.12
 
 # Make composer packages executable.
 ENV PATH="/home/circleci/.composer/vendor/bin:${PATH}"
@@ -50,6 +50,23 @@ RUN curl -o /tmp/$FILENAME ${HELM_URL} \
 
 # TODO: when https://github.com/lrills/helm-unittest/issues/87 is merged,
 # switch back to using https://github.com/lrills/helm-unittest as the source
+
+# Install Node.js and Yarn.
+# The following code is based on the CircleCI Node.js Dockerfile template:
+# https://github.com/CircleCI-Public/cimg-shared/blob/main/variants/node.Dockerfile.template
+ENV NODE_VERSION 18.18.2
+RUN echo "Installing Node.js version ${NODE_VERSION}"
+RUN curl -L -o node.tar.xz "https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-x64.tar.xz" && \
+	sudo tar -xJf node.tar.xz -C /usr/local --strip-components=1 && \
+	rm node.tar.xz && \
+	sudo ln -s /usr/local/bin/node /usr/local/bin/nodejs
+
+ENV YARN_VERSION 1.22.19
+RUN curl -L -o yarn.tar.gz "https://yarnpkg.com/downloads/${YARN_VERSION}/yarn-v${YARN_VERSION}.tar.gz" && \
+	sudo tar -xzf yarn.tar.gz -C /opt/ && \
+	rm yarn.tar.gz && \
+	sudo ln -s /opt/yarn-v${YARN_VERSION}/bin/yarn /usr/local/bin/yarn && \
+	sudo ln -s /opt/yarn-v${YARN_VERSION}/bin/yarnpkg /usr/local/bin/yarnpkg \
 
 # Add custom php config and lift memory limit.
 COPY conf/php/memory.ini /usr/local/etc/php/conf.d/memory.ini

--- a/silta-cicd/circleci-php8.2-node18-composer2/README.md
+++ b/silta-cicd/circleci-php8.2-node18-composer2/README.md
@@ -1,13 +1,16 @@
 # silta-circleci
-A docker image used circleCI, based on `cimg/php:8.1.7-node` with the following additions:
+A docker image used circleCI, based on `cimg/php:8.2.12` with the following additions:
 
 - Composer configured correctly
 - Drush-launcher and coder pre-installed
 - Vim, useful for debugging
 - kubernetes and helm
+- Node.js
+- Yarn
 
 ## Versions
 - PHP: 8.2.0
 - Composer: 2.1.12
-- Node: 18.12.1
+- Node: 18.18.2
+- Yarn: 1.22.19
 - Helm: v3.14.0

--- a/silta-cicd/circleci-php8.2-node18-composer2/TAGS
+++ b/silta-cicd/circleci-php8.2-node18-composer2/TAGS
@@ -1,3 +1,3 @@
 circleci-php8.2-node18-composer2-v1
-circleci-php8.2-node18-composer2-v1.3
-circleci-php8.2-node18-composer2-v1.3.0
+circleci-php8.2-node18-composer2-v1.4
+circleci-php8.2-node18-composer2-v1.4.0

--- a/silta-cicd/circleci-php8.2-node20-composer2/Dockerfile
+++ b/silta-cicd/circleci-php8.2-node20-composer2/Dockerfile
@@ -1,4 +1,4 @@
-FROM cimg/php:8.2.13-node
+FROM cimg/php:8.2.13
 
 # Make composer packages executable.
 ENV PATH="/home/circleci/.composer/vendor/bin:${PATH}"
@@ -50,6 +50,23 @@ RUN curl -o /tmp/$FILENAME ${HELM_URL} \
 
 # TODO: when https://github.com/lrills/helm-unittest/issues/87 is merged,
 # switch back to using https://github.com/lrills/helm-unittest as the source
+
+# Install Node.js and Yarn.
+# The following code is based on the CircleCI Node.js Dockerfile template:
+# https://github.com/CircleCI-Public/cimg-shared/blob/main/variants/node.Dockerfile.template
+ENV NODE_VERSION 20.9.0
+RUN echo "Installing Node.js version ${NODE_VERSION}"
+RUN curl -L -o node.tar.xz "https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-x64.tar.xz" && \
+	sudo tar -xJf node.tar.xz -C /usr/local --strip-components=1 && \
+	rm node.tar.xz && \
+	sudo ln -s /usr/local/bin/node /usr/local/bin/nodejs
+
+ENV YARN_VERSION 1.22.19
+RUN curl -L -o yarn.tar.gz "https://yarnpkg.com/downloads/${YARN_VERSION}/yarn-v${YARN_VERSION}.tar.gz" && \
+	sudo tar -xzf yarn.tar.gz -C /opt/ && \
+	rm yarn.tar.gz && \
+	sudo ln -s /opt/yarn-v${YARN_VERSION}/bin/yarn /usr/local/bin/yarn && \
+	sudo ln -s /opt/yarn-v${YARN_VERSION}/bin/yarnpkg /usr/local/bin/yarnpkg
 
 # Add custom php config and lift memory limit.
 COPY conf/php/memory.ini /usr/local/etc/php/conf.d/memory.ini

--- a/silta-cicd/circleci-php8.2-node20-composer2/README.md
+++ b/silta-cicd/circleci-php8.2-node20-composer2/README.md
@@ -1,13 +1,16 @@
 # silta-circleci
-A docker image used circleCI, based on `cimg/php:8.2.13-node` with the following additions:
+A docker image used circleCI, based on `cimg/php:8.2.13` with the following additions:
 
 - Composer configured correctly
 - Drush-launcher and coder pre-installed
 - Vim, useful for debugging
 - kubernetes and helm
+- Node.js
+- Yarn
 
 ## Versions
 - PHP: 8.2.13
 - Composer: 2.5.1
 - Node: 20.9.0
+- Yarn: 1.22.19
 - Helm: v3.14.0

--- a/silta-cicd/circleci-php8.2-node20-composer2/TAGS
+++ b/silta-cicd/circleci-php8.2-node20-composer2/TAGS
@@ -1,3 +1,3 @@
 circleci-php8.2-node20-composer2-v1
-circleci-php8.2-node20-composer2-v1.2
-circleci-php8.2-node20-composer2-v1.2.0
+circleci-php8.2-node20-composer2-v1.3
+circleci-php8.2-node20-composer2-v1.3.0


### PR DESCRIPTION
### After merging, remove test tag: https://hub.docker.com/layers/wunderio/silta-cicd/circleci-php8.2-node20-composer2-v1-test20240529/images/sha256-58405efb63a4e735590daa23e62b36cb9da1238b1c9d4ff364f559ba6516bc30?context=repo

Proposed changes:
- For cicd images using cimg/php as base image: Do not use the `-node` variant of the base image. Instead install node.js and yarn ourselves to gain full control over their versions, and so it allows us to update base image patch versions.
- The code for installing nodejs and yarn is directly taken from the cimg/php:x.x.x-node template
- The node.js and yarn versions used in this PR are the exact same ones that the cicd images currenlty use, so no change there

Follow up to this PR will be updating the cimg/php base images to their latest patch versions, and updating Node.js and Yarn also to the latest patch versions.

All three test sites were built successfully:
- https://app.circleci.com/pipelines/github/wunderio/drupal-project-k8s/6230/workflows/61f1f5bf-e959-4f42-8500-e80cbdbffb56
- https://app.circleci.com/pipelines/github/wunderio/frontend-project-k8s/1301/workflows/2bcf835c-ef16-44ff-846f-57ed1308ca32
- https://app.circleci.com/pipelines/github/wunderio/simple-project-k8s/639/workflows/e06c235d-39a4-49e1-8c88-e8fb2d4e53a9