### PR TITLE
Add an image for node23

### DIFF
--- a/silta-node/23-alpine/Dockerfile
+++ b/silta-node/23-alpine/Dockerfile
@@ -1,0 +1,17 @@
+FROM node:23.11.1-alpine3.21
+
+RUN apk add --no-cache openssh bash curl tzdata 'rsync>3.4.0'
+EXPOSE 22
+
+RUN mkdir /etc/ssh/keys
+
+# Copy scripts
+COPY gitauth_keys.sh /etc/ssh/
+COPY entrypoint.sh /
+COPY silta /silta
+
+ENTRYPOINT ["/entrypoint.sh"]
+
+WORKDIR /app
+
+CMD npm run start

--- a/silta-node/23-alpine/TAGS
+++ b/silta-node/23-alpine/TAGS
@@ -1,0 +1,3 @@
+23-alpine-v1
+23-alpine-v1.0
+23-alpine-v1.0.0

--- a/silta-node/23-alpine/entrypoint.sh
+++ b/silta-node/23-alpine/entrypoint.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+
+# Trigger silta entrypoint scripts if present.
+if [ -f /silta/entrypoint.sh ] ; then /silta/entrypoint.sh ; fi
+
+if [[ -v GITAUTH_URL ]]; then
+
+    if [[ ! -f /etc/ssh/keys/ssh_host_rsa_key ]]; then
+        # Generate new SSH fingerprint
+        ssh-keygen -f /etc/ssh/keys/ssh_host_rsa_key -N '' -t rsa
+        ssh-keygen -f /etc/ssh/keys/ssh_host_dsa_key -N '' -t dsa
+        ssh-keygen -f /etc/ssh/keys/ssh_host_ecdsa_key -N '' -t ecdsa
+        ssh-keygen -f /etc/ssh/keys/ssh_host_ed25519_key -N '' -t ed25519
+    fi
+
+    # SSHD settings
+    sed -i 's/^PasswordAuthentication .*/PasswordAuthentication no/' /etc/ssh/sshd_config
+    sed -i 's/^#UseDNS .*/UseDNS no/' /etc/ssh/sshd_config
+    sed -i 's/^#PrintMotd .*/PrintMotd no/' /etc/ssh/sshd_config
+    sed -i 's/^#PermitUserEnvironment .*/PermitUserEnvironment yes/' /etc/ssh/sshd_config
+    sed -i 's/^#ChallengeResponseAuthentication .*/ChallengeResponseAuthentication no/' /etc/ssh/sshd_config
+    sed -i 's/^#ClientAliveInterval .*/ClientAliveInterval 120/' /etc/ssh/sshd_config
+    sed -i 's/^#ClientAliveCountMax .*/ClientAliveCountMax 30/' /etc/ssh/sshd_config
+    sed -i 's/^AllowTcpForwarding .*/AllowTcpForwarding yes/' /etc/ssh/sshd_config
+    sed -i 's/^#PermitTunnel .*/PermitTunnel yes/' /etc/ssh/sshd_config
+
+    sed -i 's/^#HostKey \/etc\/ssh\/ssh_host_rsa_key/HostKey \/etc\/ssh\/keys\/ssh_host_rsa_key/' /etc/ssh/sshd_config
+    sed -i 's/^#HostKey \/etc\/ssh\/ssh_host_dsa_key/HostKey \/etc\/ssh\/keys\/ssh_host_dsa_key/' /etc/ssh/sshd_config
+    sed -i 's/^#HostKey \/etc\/ssh\/ssh_host_ecdsa_key/HostKey \/etc\/ssh\/keys\/ssh_host_ecdsa_key/' /etc/ssh/sshd_config
+    sed -i 's/^#HostKey \/etc\/ssh\/ssh_host_ed25519_key/HostKey \/etc\/ssh\/keys\/ssh_host_ed25519_key/' /etc/ssh/sshd_config
+
+    sed -i 's/^#AuthorizedKeysCommandUser .*/AuthorizedKeysCommandUser nobody/' /etc/ssh/sshd_config
+    sed -i 's/^#AuthorizedKeysCommand .*/AuthorizedKeysCommand \/etc\/ssh\/gitauth_keys.sh %f/' /etc/ssh/sshd_config
+
+    # AuthorizedKeysCommand does not read environment variables, so we use them with `source`
+    cat > /etc/ssh/gitauth_keys.env << EOF
+GITAUTH_URL=${GITAUTH_URL}
+GITAUTH_SCOPE=${GITAUTH_SCOPE}
+GITAUTH_USERNAME=${GITAUTH_USERNAME}
+GITAUTH_PASSWORD=${GITAUTH_PASSWORD}
+OUTSIDE_COLLABORATORS=${OUTSIDE_COLLABORATORS}
+EOF
+
+    env > /etc/environment
+    # We add -D to make it non-interactive, but then the user is locked out.
+    adduser www-admin -D -G node -s /bin/bash -h /app
+    # So set an empty password after the user is created.
+    echo "www-admin:" | chpasswd
+
+    # Pass environment variables down to container, so SSH can pick it up and drush commands work too.
+    mkdir ~www-admin/.ssh/
+    env | grep -v HOME > ~www-admin/.ssh/environment
+
+    echo "umask 0002" >> ~www-admin/.profile
+
+    # run SSH server
+    /usr/sbin/sshd -E /proc/self/fd/2
+fi
+
+# Call the CMD instruction of the Dockerfile.
+exec "$@"

--- a/silta-node/23-alpine/gitauth_keys.sh
+++ b/silta-node/23-alpine/gitauth_keys.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+# AuthorizedKeysCommand does not have environment variables, so we use them with `source`
+source "${0%/*}/gitauth_keys.env"
+
+echo "$(curl -s -u ${GITAUTH_USERNAME}:${GITAUTH_PASSWORD} ${GITAUTH_URL}\?scope=${GITAUTH_SCOPE}\&outside_collaborators=${OUTSIDE_COLLABORATORS}\&fingerprint=${1})"

--- a/silta-node/23-alpine/silta/.bashrc
+++ b/silta-node/23-alpine/silta/.bashrc
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+source /silta/entrypoints/00-umask.sh
+
+if [ "${PS1-}" ]; then
+    PS1="\w$ "
+fi

--- a/silta-node/23-alpine/silta/entrypoint.sh
+++ b/silta-node/23-alpine/silta/entrypoint.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env sh
+set -e
+
+## Run startup scripts
+for f in $(dirname "$0")/entrypoints/*.sh; do
+  if [ -r $f ]; then
+    . "$f"
+  fi
+done

--- a/silta-node/23-alpine/silta/entrypoints/00-umask.sh
+++ b/silta-node/23-alpine/silta/entrypoints/00-umask.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env sh
+
+umask 002


### PR DESCRIPTION
Adds:
 - silta-node:23-alpine-v1 (with tags for v1.0 and v1.0.0 as well).

Tested both locally, and in frontend-project-k8s successfully.
https://app.circleci.com/pipelines/github/wunderio/frontend-project-k8s/1586/workflows/e0966f2d-dcb2-45ea-b90b-d0f83c5c922a/jobs/4049