### PR TITLE
Removes pre-installed Drush launcher, uses vendor version

### DIFF
--- a/silta-cicd/circleci-php8.1-node16-composer2/Dockerfile
+++ b/silta-cicd/circleci-php8.1-node16-composer2/Dockerfile
@@ -1,15 +1,10 @@
 FROM cimg/php:8.1.31
 
 # Make composer packages executable.
-ENV PATH="/home/circleci/.composer/vendor/bin:${PATH}"
+ENV PATH="/home/circleci/.composer/vendor/bin:/home/circleci/project/vendor/drush/drush:${PATH}"
 
 # Upgrade packages
 RUN sudo apt update && sudo apt upgrade && sudo apt clean
-
-# Install drush
-ENV DRUSH_LAUNCHER_VERSION 0.9.1
-RUN sudo wget -q https://github.com/drush-ops/drush-launcher/releases/download/${DRUSH_LAUNCHER_VERSION}/drush.phar -O /usr/local/bin/drush \
-  && sudo chmod +x /usr/local/bin/drush
 
 # Install vim based on popular demand.
 RUN sudo apt-get update && sudo apt-get install vim && sudo apt-get clean

--- a/silta-cicd/circleci-php8.1-node16-composer2/Dockerfile
+++ b/silta-cicd/circleci-php8.1-node16-composer2/Dockerfile
@@ -1,7 +1,7 @@
 FROM cimg/php:8.1.31
 
 # Make composer packages executable.
-ENV PATH="/home/circleci/.composer/vendor/bin:/home/circleci/project/vendor/drush/drush:${PATH}"
+ENV PATH="/home/circleci/.composer/vendor/bin:/home/circleci/project/vendor/drush/drush:/home/circleci/project/drupal/vendor/drush/drush:${PATH}"
 
 # Upgrade packages
 RUN sudo apt update && sudo apt upgrade && sudo apt clean

--- a/silta-cicd/circleci-php8.1-node16-composer2/README.md
+++ b/silta-cicd/circleci-php8.1-node16-composer2/README.md
@@ -2,7 +2,6 @@
 A docker image used circleCI, based on `cimg/php:8.1.31` with the following additions:
 
 - Composer configured correctly
-- Drush-launcher and coder pre-installed
 - Vim, useful for debugging
 - kubernetes and helm
 - Node.js

--- a/silta-cicd/circleci-php8.1-node16-composer2/TAGS
+++ b/silta-cicd/circleci-php8.1-node16-composer2/TAGS
@@ -1,3 +1,3 @@
 circleci-php8.1-node16-composer2-v1
-circleci-php8.1-node16-composer2-v1.7
-circleci-php8.1-node16-composer2-v1.7.0
+circleci-php8.1-node16-composer2-v1.8
+circleci-php8.1-node16-composer2-v1.8.0

--- a/silta-cicd/circleci-php8.1-node18-composer2/Dockerfile
+++ b/silta-cicd/circleci-php8.1-node18-composer2/Dockerfile
@@ -1,15 +1,10 @@
 FROM cimg/php:8.1.31
 
 # Make composer packages executable.
-ENV PATH="/home/circleci/.composer/vendor/bin:${PATH}"
+ENV PATH="/home/circleci/.composer/vendor/bin:/home/circleci/project/vendor/drush/drush:${PATH}"
 
 # Upgrade packages
 RUN sudo apt update && sudo apt upgrade && sudo apt clean
-
-# Install drush
-ENV DRUSH_LAUNCHER_VERSION 0.9.1
-RUN sudo wget -q https://github.com/drush-ops/drush-launcher/releases/download/${DRUSH_LAUNCHER_VERSION}/drush.phar -O /usr/local/bin/drush \
-  && sudo chmod +x /usr/local/bin/drush
 
 # Install vim based on popular demand.
 RUN sudo apt-get update && sudo apt-get install vim && sudo apt-get clean

--- a/silta-cicd/circleci-php8.1-node18-composer2/Dockerfile
+++ b/silta-cicd/circleci-php8.1-node18-composer2/Dockerfile
@@ -1,7 +1,7 @@
 FROM cimg/php:8.1.31
 
 # Make composer packages executable.
-ENV PATH="/home/circleci/.composer/vendor/bin:/home/circleci/project/vendor/drush/drush:${PATH}"
+ENV PATH="/home/circleci/.composer/vendor/bin:/home/circleci/project/vendor/drush/drush:/home/circleci/project/drupal/vendor/drush/drush:${PATH}"
 
 # Upgrade packages
 RUN sudo apt update && sudo apt upgrade && sudo apt clean

--- a/silta-cicd/circleci-php8.1-node18-composer2/README.md
+++ b/silta-cicd/circleci-php8.1-node18-composer2/README.md
@@ -2,7 +2,6 @@
 A docker image used circleCI, based on `cimg/php:8.1.31` with the following additions:
 
 - Composer configured correctly
-- Drush-launcher and coder pre-installed
 - Vim, useful for debugging
 - kubernetes and helm
 - Node.js

--- a/silta-cicd/circleci-php8.1-node18-composer2/TAGS
+++ b/silta-cicd/circleci-php8.1-node18-composer2/TAGS
@@ -1,3 +1,3 @@
 circleci-php8.1-node18-composer2-v1
-circleci-php8.1-node18-composer2-v1.7
-circleci-php8.1-node18-composer2-v1.7.0
+circleci-php8.1-node18-composer2-v1.8
+circleci-php8.1-node18-composer2-v1.8.0

--- a/silta-cicd/circleci-php8.2-node16-composer2/Dockerfile
+++ b/silta-cicd/circleci-php8.2-node16-composer2/Dockerfile
@@ -1,7 +1,7 @@
 FROM cimg/php:8.2.26
 
 # Make composer packages executable.
-ENV PATH="/home/circleci/.composer/vendor/bin:/home/circleci/project/vendor/drush/drush:${PATH}"
+ENV PATH="/home/circleci/.composer/vendor/bin:/home/circleci/project/vendor/drush/drush:/home/circleci/project/drupal/vendor/drush/drush:${PATH}"
 
 # Upgrade packages
 RUN sudo apt update && sudo apt upgrade && sudo apt clean

--- a/silta-cicd/circleci-php8.2-node16-composer2/Dockerfile
+++ b/silta-cicd/circleci-php8.2-node16-composer2/Dockerfile
@@ -1,15 +1,10 @@
 FROM cimg/php:8.2.26
 
 # Make composer packages executable.
-ENV PATH="/home/circleci/.composer/vendor/bin:${PATH}"
+ENV PATH="/home/circleci/.composer/vendor/bin:/home/circleci/project/vendor/drush/drush:${PATH}"
 
 # Upgrade packages
 RUN sudo apt update && sudo apt upgrade && sudo apt clean
-
-# Install drush
-ENV DRUSH_LAUNCHER_VERSION 0.9.1
-RUN sudo wget -q https://github.com/drush-ops/drush-launcher/releases/download/${DRUSH_LAUNCHER_VERSION}/drush.phar -O /usr/local/bin/drush \
-  && sudo chmod +x /usr/local/bin/drush
 
 # Install vim based on popular demand.
 RUN sudo apt-get update && sudo apt-get install vim && sudo apt-get clean

--- a/silta-cicd/circleci-php8.2-node16-composer2/README.md
+++ b/silta-cicd/circleci-php8.2-node16-composer2/README.md
@@ -2,7 +2,6 @@
 A docker image used circleCI, based on `cimg/php:8.2.26` with the following additions:
 
 - Composer configured correctly
-- Drush-launcher and coder pre-installed
 - Vim, useful for debugging
 - kubernetes and helm
 - Node.js

--- a/silta-cicd/circleci-php8.2-node16-composer2/TAGS
+++ b/silta-cicd/circleci-php8.2-node16-composer2/TAGS
@@ -1,3 +1,3 @@
 circleci-php8.2-node16-composer2-v1
-circleci-php8.2-node16-composer2-v1.2
-circleci-php8.2-node16-composer2-v1.2.0
+circleci-php8.2-node16-composer2-v1.3
+circleci-php8.2-node16-composer2-v1.3.0

--- a/silta-cicd/circleci-php8.2-node18-composer2/Dockerfile
+++ b/silta-cicd/circleci-php8.2-node18-composer2/Dockerfile
@@ -1,7 +1,7 @@
 FROM cimg/php:8.2.26
 
 # Make composer packages executable.
-ENV PATH="/home/circleci/.composer/vendor/bin:/home/circleci/project/vendor/drush/drush:${PATH}"
+ENV PATH="/home/circleci/.composer/vendor/bin:/home/circleci/project/vendor/drush/drush:/home/circleci/project/drupal/vendor/drush/drush:${PATH}"
 
 # Upgrade packages
 RUN sudo apt update && sudo apt upgrade && sudo apt clean

--- a/silta-cicd/circleci-php8.2-node18-composer2/Dockerfile
+++ b/silta-cicd/circleci-php8.2-node18-composer2/Dockerfile
@@ -1,15 +1,10 @@
 FROM cimg/php:8.2.26
 
 # Make composer packages executable.
-ENV PATH="/home/circleci/.composer/vendor/bin:${PATH}"
+ENV PATH="/home/circleci/.composer/vendor/bin:/home/circleci/project/vendor/drush/drush:${PATH}"
 
 # Upgrade packages
 RUN sudo apt update && sudo apt upgrade && sudo apt clean
-
-# Install drush
-ENV DRUSH_LAUNCHER_VERSION 0.9.1
-RUN sudo wget -q https://github.com/drush-ops/drush-launcher/releases/download/${DRUSH_LAUNCHER_VERSION}/drush.phar -O /usr/local/bin/drush \
-  && sudo chmod +x /usr/local/bin/drush
 
 # Install vim based on popular demand.
 RUN sudo apt-get update && sudo apt-get install vim && sudo apt-get clean

--- a/silta-cicd/circleci-php8.2-node18-composer2/README.md
+++ b/silta-cicd/circleci-php8.2-node18-composer2/README.md
@@ -2,7 +2,6 @@
 A docker image used circleCI, based on `cimg/php:8.2.26` with the following additions:
 
 - Composer configured correctly
-- Drush-launcher and coder pre-installed
 - Vim, useful for debugging
 - kubernetes and helm
 - Node.js

--- a/silta-cicd/circleci-php8.2-node18-composer2/TAGS
+++ b/silta-cicd/circleci-php8.2-node18-composer2/TAGS
@@ -1,3 +1,3 @@
 circleci-php8.2-node18-composer2-v1
-circleci-php8.2-node18-composer2-v1.7
-circleci-php8.2-node18-composer2-v1.7.0
+circleci-php8.2-node18-composer2-v1.8
+circleci-php8.2-node18-composer2-v1.8.0

--- a/silta-cicd/circleci-php8.2-node20-composer2/Dockerfile
+++ b/silta-cicd/circleci-php8.2-node20-composer2/Dockerfile
@@ -1,7 +1,7 @@
 FROM cimg/php:8.2.26
 
 # Make composer packages executable.
-ENV PATH="/home/circleci/.composer/vendor/bin:/home/circleci/project/vendor/drush/drush:${PATH}"
+ENV PATH="/home/circleci/.composer/vendor/bin:/home/circleci/project/vendor/drush/drush:/home/circleci/project/drupal/vendor/drush/drush:${PATH}"
 
 # Upgrade packages
 RUN sudo apt update && sudo apt upgrade && sudo apt clean

--- a/silta-cicd/circleci-php8.2-node20-composer2/Dockerfile
+++ b/silta-cicd/circleci-php8.2-node20-composer2/Dockerfile
@@ -1,15 +1,10 @@
 FROM cimg/php:8.2.26
 
 # Make composer packages executable.
-ENV PATH="/home/circleci/.composer/vendor/bin:${PATH}"
+ENV PATH="/home/circleci/.composer/vendor/bin:/home/circleci/project/vendor/drush/drush:${PATH}"
 
 # Upgrade packages
 RUN sudo apt update && sudo apt upgrade && sudo apt clean
-
-# Install drush
-ENV DRUSH_LAUNCHER_VERSION 0.9.1
-RUN sudo wget -q https://github.com/drush-ops/drush-launcher/releases/download/${DRUSH_LAUNCHER_VERSION}/drush.phar -O /usr/local/bin/drush \
-  && sudo chmod +x /usr/local/bin/drush
 
 # Install vim based on popular demand.
 RUN sudo apt-get update && sudo apt-get install vim && sudo apt-get clean

--- a/silta-cicd/circleci-php8.2-node20-composer2/README.md
+++ b/silta-cicd/circleci-php8.2-node20-composer2/README.md
@@ -2,7 +2,6 @@
 A docker image used circleCI, based on `cimg/php:8.2.26` with the following additions:
 
 - Composer configured correctly
-- Drush-launcher and coder pre-installed
 - Vim, useful for debugging
 - kubernetes and helm
 - Node.js

--- a/silta-cicd/circleci-php8.2-node20-composer2/TAGS
+++ b/silta-cicd/circleci-php8.2-node20-composer2/TAGS
@@ -1,3 +1,3 @@
 circleci-php8.2-node20-composer2-v1
-circleci-php8.2-node20-composer2-v1.6
-circleci-php8.2-node20-composer2-v1.6.0
+circleci-php8.2-node20-composer2-v1.7
+circleci-php8.2-node20-composer2-v1.7.0

--- a/silta-cicd/circleci-php8.2-node22-composer2/Dockerfile
+++ b/silta-cicd/circleci-php8.2-node22-composer2/Dockerfile
@@ -1,7 +1,7 @@
 FROM cimg/php:8.2.26
 
 # Make composer packages executable.
-ENV PATH="/home/circleci/.composer/vendor/bin:/home/circleci/project/vendor/drush/drush:${PATH}"
+ENV PATH="/home/circleci/.composer/vendor/bin:/home/circleci/project/vendor/drush/drush:/home/circleci/project/drupal/vendor/drush/drush:${PATH}"
 
 # Upgrade packages
 RUN sudo apt update && sudo apt upgrade && sudo apt clean

--- a/silta-cicd/circleci-php8.2-node22-composer2/Dockerfile
+++ b/silta-cicd/circleci-php8.2-node22-composer2/Dockerfile
@@ -1,15 +1,10 @@
 FROM cimg/php:8.2.26
 
 # Make composer packages executable.
-ENV PATH="/home/circleci/.composer/vendor/bin:${PATH}"
+ENV PATH="/home/circleci/.composer/vendor/bin:/home/circleci/project/vendor/drush/drush:${PATH}"
 
 # Upgrade packages
 RUN sudo apt update && sudo apt upgrade && sudo apt clean
-
-# Install drush
-ENV DRUSH_LAUNCHER_VERSION 0.9.1
-RUN sudo wget -q https://github.com/drush-ops/drush-launcher/releases/download/${DRUSH_LAUNCHER_VERSION}/drush.phar -O /usr/local/bin/drush \
-  && sudo chmod +x /usr/local/bin/drush
 
 # Install vim based on popular demand.
 RUN sudo apt-get update && sudo apt-get install vim && sudo apt-get clean

--- a/silta-cicd/circleci-php8.2-node22-composer2/README.md
+++ b/silta-cicd/circleci-php8.2-node22-composer2/README.md
@@ -2,7 +2,6 @@
 A docker image used circleCI, based on `cimg/php:8.2.26` with the following additions:
 
 - Composer configured correctly
-- Drush-launcher and coder pre-installed
 - Vim, useful for debugging
 - kubernetes and helm
 - Node.js

--- a/silta-cicd/circleci-php8.2-node22-composer2/TAGS
+++ b/silta-cicd/circleci-php8.2-node22-composer2/TAGS
@@ -1,3 +1,3 @@
 circleci-php8.2-node22-composer2-v1
-circleci-php8.2-node22-composer2-v1.2
-circleci-php8.2-node22-composer2-v1.2.0
+circleci-php8.2-node22-composer2-v1.3
+circleci-php8.2-node22-composer2-v1.3.0

--- a/silta-cicd/circleci-php8.2-node22-composer2/TAGS
+++ b/silta-cicd/circleci-php8.2-node22-composer2/TAGS
@@ -1,3 +1,3 @@
 circleci-php8.2-node22-composer2-v1
-circleci-php8.2-node22-composer2-v1.3
-circleci-php8.2-node22-composer2-v1.3.0
+circleci-php8.2-node22-composer2-v1.4
+circleci-php8.2-node22-composer2-v1.4.0

--- a/silta-cicd/circleci-php8.3-node18-composer2/Dockerfile
+++ b/silta-cicd/circleci-php8.3-node18-composer2/Dockerfile
@@ -1,7 +1,7 @@
 FROM cimg/php:8.3.14
 
 # Make composer packages executable.
-ENV PATH="/home/circleci/.composer/vendor/bin:/home/circleci/project/vendor/drush/drush:${PATH}"
+ENV PATH="/home/circleci/.composer/vendor/bin:/home/circleci/project/vendor/drush/drush:/home/circleci/project/drupal/vendor/drush/drush:${PATH}"
 
 # Upgrade packages
 RUN sudo apt update && sudo apt upgrade && sudo apt clean

--- a/silta-cicd/circleci-php8.3-node18-composer2/Dockerfile
+++ b/silta-cicd/circleci-php8.3-node18-composer2/Dockerfile
@@ -1,15 +1,10 @@
 FROM cimg/php:8.3.14
 
 # Make composer packages executable.
-ENV PATH="/home/circleci/.composer/vendor/bin:${PATH}"
+ENV PATH="/home/circleci/.composer/vendor/bin:/home/circleci/project/vendor/drush/drush:${PATH}"
 
 # Upgrade packages
 RUN sudo apt update && sudo apt upgrade && sudo apt clean
-
-# Install drush
-ENV DRUSH_LAUNCHER_VERSION 0.9.1
-RUN sudo wget -q https://github.com/drush-ops/drush-launcher/releases/download/${DRUSH_LAUNCHER_VERSION}/drush.phar -O /usr/local/bin/drush \
-  && sudo chmod +x /usr/local/bin/drush
 
 # Install vim based on popular demand.
 RUN sudo apt-get update && sudo apt-get install vim && sudo apt-get clean

--- a/silta-cicd/circleci-php8.3-node18-composer2/README.md
+++ b/silta-cicd/circleci-php8.3-node18-composer2/README.md
@@ -2,7 +2,6 @@
 A docker image used circleCI, based on `cimg/php:8.3.14` with the following additions:
 
 - Composer configured correctly
-- Drush-launcher and coder pre-installed
 - Vim, useful for debugging
 - kubernetes and helm
 - Node.js

--- a/silta-cicd/circleci-php8.3-node18-composer2/TAGS
+++ b/silta-cicd/circleci-php8.3-node18-composer2/TAGS
@@ -1,3 +1,3 @@
 circleci-php8.3-node18-composer2-v1
-circleci-php8.3-node18-composer2-v1.1
-circleci-php8.3-node18-composer2-v1.1.0
+circleci-php8.3-node18-composer2-v1.2
+circleci-php8.3-node18-composer2-v1.2.0

--- a/silta-cicd/circleci-php8.3-node20-composer2/Dockerfile
+++ b/silta-cicd/circleci-php8.3-node20-composer2/Dockerfile
@@ -1,7 +1,7 @@
 FROM cimg/php:8.3.14
 
 # Make composer packages executable.
-ENV PATH="/home/circleci/.composer/vendor/bin:/home/circleci/project/vendor/drush/drush:${PATH}"
+ENV PATH="/home/circleci/.composer/vendor/bin:/home/circleci/project/vendor/drush/drush:/home/circleci/project/drupal/vendor/drush/drush:${PATH}"
 
 # Upgrade packages
 RUN sudo apt update && sudo apt upgrade && sudo apt clean

--- a/silta-cicd/circleci-php8.3-node20-composer2/Dockerfile
+++ b/silta-cicd/circleci-php8.3-node20-composer2/Dockerfile
@@ -1,15 +1,10 @@
 FROM cimg/php:8.3.14
 
 # Make composer packages executable.
-ENV PATH="/home/circleci/.composer/vendor/bin:${PATH}"
+ENV PATH="/home/circleci/.composer/vendor/bin:/home/circleci/project/vendor/drush/drush:${PATH}"
 
 # Upgrade packages
 RUN sudo apt update && sudo apt upgrade && sudo apt clean
-
-# Install drush
-ENV DRUSH_LAUNCHER_VERSION 0.9.1
-RUN sudo wget -q https://github.com/drush-ops/drush-launcher/releases/download/${DRUSH_LAUNCHER_VERSION}/drush.phar -O /usr/local/bin/drush \
-  && sudo chmod +x /usr/local/bin/drush
 
 # Install vim based on popular demand.
 RUN sudo apt-get update && sudo apt-get install vim && sudo apt-get clean

--- a/silta-cicd/circleci-php8.3-node20-composer2/README.md
+++ b/silta-cicd/circleci-php8.3-node20-composer2/README.md
@@ -2,7 +2,6 @@
 A docker image used circleCI, based on `cimg/php:8.3.14` with the following additions:
 
 - Composer configured correctly
-- Drush-launcher and coder pre-installed
 - Vim, useful for debugging
 - kubernetes and helm
 - Node.js

--- a/silta-cicd/circleci-php8.3-node20-composer2/TAGS
+++ b/silta-cicd/circleci-php8.3-node20-composer2/TAGS
@@ -1,3 +1,3 @@
 circleci-php8.3-node20-composer2-v1
-circleci-php8.3-node20-composer2-v1.1
-circleci-php8.3-node20-composer2-v1.1.0
+circleci-php8.3-node20-composer2-v1.2
+circleci-php8.3-node20-composer2-v1.2.0

--- a/silta-cicd/circleci-php8.3-node22-composer2-sqlite3.45/Dockerfile
+++ b/silta-cicd/circleci-php8.3-node22-composer2-sqlite3.45/Dockerfile
@@ -1,15 +1,10 @@
 FROM cimg/php:8.3.19
 
 # Make composer packages executable.
-ENV PATH="/home/circleci/.composer/vendor/bin:${PATH}"
+ENV PATH="/home/circleci/.composer/vendor/bin:/home/circleci/project/vendor/drush/drush:${PATH}"
 
 # Upgrade packages
 RUN sudo apt update && sudo apt upgrade && sudo apt clean
-
-# Install drush
-ENV DRUSH_LAUNCHER_VERSION 0.9.1
-RUN sudo wget -q https://github.com/drush-ops/drush-launcher/releases/download/${DRUSH_LAUNCHER_VERSION}/drush.phar -O /usr/local/bin/drush \
-  && sudo chmod +x /usr/local/bin/drush
 
 # Install vim based on popular demand.
 RUN sudo apt-get update && sudo apt-get install vim && sudo apt-get clean

--- a/silta-cicd/circleci-php8.3-node22-composer2-sqlite3.45/Dockerfile
+++ b/silta-cicd/circleci-php8.3-node22-composer2-sqlite3.45/Dockerfile
@@ -1,7 +1,7 @@
 FROM cimg/php:8.3.19
 
 # Make composer packages executable.
-ENV PATH="/home/circleci/.composer/vendor/bin:/home/circleci/project/vendor/drush/drush:${PATH}"
+ENV PATH="/home/circleci/.composer/vendor/bin:/home/circleci/project/vendor/drush/drush:/home/circleci/project/drupal/vendor/drush/drush:${PATH}"
 
 # Upgrade packages
 RUN sudo apt update && sudo apt upgrade && sudo apt clean

--- a/silta-cicd/circleci-php8.3-node22-composer2-sqlite3.45/README.md
+++ b/silta-cicd/circleci-php8.3-node22-composer2-sqlite3.45/README.md
@@ -2,7 +2,6 @@
 A docker image used circleCI, based on `cimg/php:8.3.19` with the following additions:
 
 - Composer configured correctly
-- Drush-launcher and coder pre-installed
 - Vim, useful for debugging
 - kubernetes and helm
 - Node.js

--- a/silta-cicd/circleci-php8.3-node22-composer2-sqlite3.45/TAGS
+++ b/silta-cicd/circleci-php8.3-node22-composer2-sqlite3.45/TAGS
@@ -1,3 +1,3 @@
 circleci-php8.3-node22-composer2-sqlite3.45-v1
-circleci-php8.3-node22-composer2-sqlite3.45-v1.2
-circleci-php8.3-node22-composer2-sqlite3.45-v1.2.0
+circleci-php8.3-node22-composer2-sqlite3.45-v1.3
+circleci-php8.3-node22-composer2-sqlite3.45-v1.3.0

--- a/silta-cicd/circleci-php8.3-node22-composer2-sqlite3.45/TAGS
+++ b/silta-cicd/circleci-php8.3-node22-composer2-sqlite3.45/TAGS
@@ -1,3 +1,3 @@
 circleci-php8.3-node22-composer2-sqlite3.45-v1
-circleci-php8.3-node22-composer2-sqlite3.45-v1.1
-circleci-php8.3-node22-composer2-sqlite3.45-v1.1.0
+circleci-php8.3-node22-composer2-sqlite3.45-v1.2
+circleci-php8.3-node22-composer2-sqlite3.45-v1.2.0

--- a/silta-cicd/circleci-php8.3-node22-composer2/Dockerfile
+++ b/silta-cicd/circleci-php8.3-node22-composer2/Dockerfile
@@ -1,7 +1,7 @@
 FROM cimg/php:8.3.14
 
 # Make composer packages executable.
-ENV PATH="/home/circleci/.composer/vendor/bin:/home/circleci/project/vendor/drush/drush:${PATH}"
+ENV PATH="/home/circleci/.composer/vendor/bin:/home/circleci/project/vendor/drush/drush:/home/circleci/project/drupal/vendor/drush/drush:${PATH}"
 
 # Upgrade packages
 RUN sudo apt update && sudo apt upgrade && sudo apt clean

--- a/silta-cicd/circleci-php8.3-node22-composer2/Dockerfile
+++ b/silta-cicd/circleci-php8.3-node22-composer2/Dockerfile
@@ -1,15 +1,10 @@
 FROM cimg/php:8.3.14
 
 # Make composer packages executable.
-ENV PATH="/home/circleci/.composer/vendor/bin:${PATH}"
+ENV PATH="/home/circleci/.composer/vendor/bin:/home/circleci/project/vendor/drush/drush:${PATH}"
 
 # Upgrade packages
 RUN sudo apt update && sudo apt upgrade && sudo apt clean
-
-# Install drush
-ENV DRUSH_LAUNCHER_VERSION 0.9.1
-RUN sudo wget -q https://github.com/drush-ops/drush-launcher/releases/download/${DRUSH_LAUNCHER_VERSION}/drush.phar -O /usr/local/bin/drush \
-  && sudo chmod +x /usr/local/bin/drush
 
 # Install vim based on popular demand.
 RUN sudo apt-get update && sudo apt-get install vim && sudo apt-get clean

--- a/silta-cicd/circleci-php8.3-node22-composer2/README.md
+++ b/silta-cicd/circleci-php8.3-node22-composer2/README.md
@@ -2,7 +2,6 @@
 A docker image used circleCI, based on `cimg/php:8.3.14` with the following additions:
 
 - Composer configured correctly
-- Drush-launcher and coder pre-installed
 - Vim, useful for debugging
 - kubernetes and helm
 - Node.js

--- a/silta-cicd/circleci-php8.3-node22-composer2/TAGS
+++ b/silta-cicd/circleci-php8.3-node22-composer2/TAGS
@@ -1,3 +1,3 @@
 circleci-php8.3-node22-composer2-v1
-circleci-php8.3-node22-composer2-v1.2
-circleci-php8.3-node22-composer2-v1.2.0
+circleci-php8.3-node22-composer2-v1.3
+circleci-php8.3-node22-composer2-v1.3.0

--- a/silta-cicd/circleci-php8.3-node22-composer2/TAGS
+++ b/silta-cicd/circleci-php8.3-node22-composer2/TAGS
@@ -1,3 +1,3 @@
 circleci-php8.3-node22-composer2-v1
-circleci-php8.3-node22-composer2-v1.1
-circleci-php8.3-node22-composer2-v1.1.0
+circleci-php8.3-node22-composer2-v1.2
+circleci-php8.3-node22-composer2-v1.2.0


### PR DESCRIPTION
The assumed location of vendor folder is in project folder (which is a default path for projects). If the path differs or drupal is located in a subdirectory, project has to adjust PATH accordingly.